### PR TITLE
Bug notifica circolari a destintario di tipo gruppo: workaround.

### DIFF
--- a/inc/admin/circolare.php
+++ b/inc/admin/circolare.php
@@ -297,7 +297,13 @@ function dsi_feedback_circolare( $post_id, $post )
 
     if(count($users)){
         foreach ($users as $user){
-            dsi_notify_circolare_to_user($user->ID, $post);
+            // in caso di destinatari di tipo "gruppo" get_objects_in_term restituisce un array di interi, negli altri casi l'array contiene oggetti WP_User
+            if (is_a($user, 'WP_User')) {
+                $userId=$user->ID;
+            } else {
+                $userId=$user;
+            }
+            dsi_notify_circolare_to_user($userId, $post);
         }
         update_post_meta($post->ID, "_dsi_notificato", "true");
     }


### PR DESCRIPTION
Riproduzione bug
1) Creazione gruppo
2) Associazione utente a gruppo
3) Creazione circolare, come "Destinatari della circolare"  selezionare "Seleziona in base al gruppo"
4) Selezionare gruppo
5) Pubblicare circolare 

La funzione "get_objects_in_term" ritorna un array di interi come da documentazione:
"[Return] An array of object IDs as numeric strings on success"
https://developer.wordpress.org/reference/functions/get_objects_in_term/

Negli altri casi è ritornato un array di oggetti.

La correzione consiste nel controllare il tipo di elemento presente nell'array e recuperare l'id utente.


