### PR TITLE
Update skiplink.php

### DIFF
--- a/template-parts/common/skiplink.php
+++ b/template-parts/common/skiplink.php
@@ -4,4 +4,3 @@
 	<a class="sr-only sr-only-focusable" href="#footer-wrapper"><?php _e("Vai al footer", "design_scuole_italia"); ?></a>
 	</ul>
 </div><!-- /skiplink -->
-	<?php


### PR DESCRIPTION
Wrong code in the final row in the file template-parts/common/skiplink.php: 

"<?php"

of course this code results in a parse error.

Removing it the template works.