### PR TITLE
fix: single-evento foto e video

### DIFF
--- a/single-evento.php
+++ b/single-evento.php
@@ -419,26 +419,26 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                 </div><!-- /container -->
             </section>
 
-            <section class="section bg-gray-light py-5" id="art-par-04">
-                <div class="container py-4">
-                    <div class="title-section text-center mb-5">
-                        <h2 class="h4">Foto e video</h2>
-                    </div><!-- /title-large -->
-                    <div class="row variable-gutters">
-                        <div class="col">
-                        <?php if ( is_array( $gallery ) && count( $gallery ) > 0 ) { ?>
-                            <div class="it-carousel-wrapper simple-two-carousel splide" data-bs-carousel-splide>
-                                <div class="splide__track">
-                                    <ul class="splide__list">
-                                    <?php get_template_part( "template-parts/single/gallery", $post->post_type ); ?>
-                                    </ul>
-                                </div><!-- /carousel-simple -->
-                            </div>
-                        <?php } ?>
-                        </div><!-- /col -->
-                    </div><!-- /row -->
-                </div><!-- /container -->
-            </section>
+            <?php if ( is_array( $gallery ) && count( $gallery ) > 0 ) { ?>
+                <section class="section bg-gray-light py-5" id="art-par-04">
+                    <div class="container py-4">
+                        <div class="title-section text-center mb-5">
+                            <h2 class="h4">Foto e video</h2>
+                        </div><!-- /title-large -->
+                        <div class="row variable-gutters">
+                            <div class="col">
+                                <div class="it-carousel-wrapper simple-two-carousel splide" data-bs-carousel-splide>
+                                    <div class="splide__track">
+                                        <ul class="splide__list">
+                                        <?php get_template_part( "template-parts/single/gallery", $post->post_type ); ?>
+                                        </ul>
+                                    </div><!-- /carousel-simple -->
+                                </div>
+                            </div><!-- /col -->
+                        </div><!-- /row -->
+                    </div><!-- /container -->
+                </section>
+            <?php } ?>
 
 			<?php get_template_part("template-parts/single/more-posts"); ?>
 


### PR DESCRIPTION
Pull Request relativa alla issue #135.

### Descrizione
Sezione foto e video non presente se il singolo evento manca di foto e video.

### Risultato PRIMA dell'applicazione della Pull Request
Nel caso il singolo evento non contenga né foto né video viene visualizzata la sezione foto e video vuota.

### Risultato DOPO l'applicazione della Pull Request 
Nel caso il singolo evento non contenga né foto né video non viene visualizzata la sezione foto e video vuota.

### Ambiente
WordPress 6.1.1
PHP 8.1.6
Tema 2.1.0