### PR TITLE
Problema accessibilità header

### DIFF
--- a/template-parts/header/header-anon.php
+++ b/template-parts/header/header-anon.php
@@ -1,4 +1,4 @@
-<button type="button" class="icon-text" data-toggle="modal" data-target="#access-modal">
+<button type="button" class="icon-text" aria-label="<?php _e("Accedi", "design_scuole_italia"); ?>" data-toggle="modal" data-target="#access-modal">
     <span class="mr-2 d-none d-lg-block"><?php _e("Accedi", "design_scuole_italia"); ?></span>
     <div class="icon-wrapper">
         <svg class="svg-user"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-user"></use></svg>


### PR DESCRIPTION
Ho aggiunto "aria-label" al botton Accedi. Questo risolve il problema agli screen reader. Testando il sito con "app-valutazione-scuole" porta la voce "Test aggiuntivi" da 89 a 93.

**Prima**
![prima](https://user-images.githubusercontent.com/48310974/207840274-eab8e568-2421-4ece-a288-eb6287b1d222.PNG)

**Dopo**
![dopo](https://user-images.githubusercontent.com/48310974/207839622-3dba263c-6334-4dfb-8363-96e814260ab9.PNG)
