### PR TITLE
R.SC.1.2

### DIFF
--- a/walkers/header-walker.php
+++ b/walkers/header-walker.php
@@ -20,7 +20,7 @@ class Header_Menu_Walker extends Walker_Nav_Menu {
 		$output .= "<li>";
 		$custom_data = '';
 
-		if ( stripos( $item->post_name, 'personale-scolastico' ) !== false || stripos( $item->post_name, 'famiglie-e-studenti' ) !== false ) {
+		if( stripos( $item->post_type, 'nav_menu_item' ) !== false && stripos( get_post_meta( $item->ID, '_menu_item_object', true ), 'tipologia-servizio' ) !== false ) {
 			$custom_data = 'data-element="service-type"';
 		}
 


### PR DESCRIPTION
Tramite l'applicativo di valutazione ho notato il problema evidenziato nella issue #193  
Ringrazio @attiliopecora per la descrizione accurata. 
Ho dato un'occhiata al database, in particolate ai post_meta dei post di tipo 'nav_menu_item'. 
All'interno dei post_meta c'è il meta_key **'_menu_item_object'**. Nel caso dei post **'personale-scolastico'** e **'famiglie-e-studenti'** il meta_value corrispondente è **'tipologia-servizio'**.
La soluzione che propongo esegue un controllo sul post_meta '_menu_item_object' e non più sul post_name

Ecco il risultato:
![raccomandazioni-progettuali](https://user-images.githubusercontent.com/48310974/208409261-a911cb52-0351-41ae-b63d-84246526a3ab.PNG)
