### PR TITLE
feat: pulsante di autenticazione SPID direttamente nella modale di accesso se presente il plugin wp-spid-italia

### DIFF
--- a/template-parts/common/access-modal.php
+++ b/template-parts/common/access-modal.php
@@ -36,10 +36,10 @@
                                     <h3><?php _e("Personale scolastico", "design_scuole_italia"); ?></h3>
                                     <p class="text-large"><?php _e("Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.", "design_scuole_italia"); ?></p>
                                     <?php if(in_array('wp-spid-italia/wp-spid-italia.php', apply_filters('active_plugins', get_option('active_plugins')))){?>
-									    <div class="col text-center pt-4">
-										<?php echo do_shortcode("[spid_login_button]"); ?>
-										</div>
-									<?php }?>
+                                        <div class="col text-center pt-4">
+                                            <?php echo do_shortcode("[spid_login_button]"); ?>
+                                        </div>
+                                    <?php }?>
                                     <div class="access-login-form">
                                         <div class="form-group">
                                             <label for="login-email-field">Email address</label>

--- a/template-parts/common/access-modal.php
+++ b/template-parts/common/access-modal.php
@@ -35,6 +35,11 @@
                                 <div class="access-login">
                                     <h3><?php _e("Personale scolastico", "design_scuole_italia"); ?></h3>
                                     <p class="text-large"><?php _e("Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.", "design_scuole_italia"); ?></p>
+                                    <?php if(in_array('wp-spid-italia/wp-spid-italia.php', apply_filters('active_plugins', get_option('active_plugins')))){?>
+									    <div class="col text-center pt-4">
+										<?php echo do_shortcode("[spid_login_button]"); ?>
+										</div>
+									<?php }?>
                                     <div class="access-login-form">
                                         <div class="form-group">
                                             <label for="login-email-field">Email address</label>


### PR DESCRIPTION
Inserisce pulsante di autenticazione SPID direttamente nella modale di accesso se presente il plugin [wp-spid-italia](https://wordpress.org/plugins/wp-spid-italia/)

<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->