### PR TITLE
fix: show structures and documents in profile page

### DIFF
--- a/author.php
+++ b/author.php
@@ -121,11 +121,34 @@ $args = array(
 $schede_progetto = get_posts($args);
 
 $args = array(
-    'author' =>  $author_id,
+    'posts_per_page' => -1,
+    'post_type' => 'struttura'
+);
+$strutture = get_posts($args);
+
+function filter_my_structures($structure) {
+    return in_array(
+        (string)$GLOBALS['author_id'],
+        get_post_meta( $structure->ID, "_dsi_struttura_persone", true )
+    );
+}
+
+$strutture = array_filter($strutture, "filter_my_structures");
+
+$args = array(
     'posts_per_page' => -1,
     'post_type' => 'documento'
 );
 $documenti = get_posts($args);
+
+function filter_my_documents($document) {
+    return in_array(
+        (string)$GLOBALS['author_id'],
+        get_post_meta( $document->ID, "_dsi_documento_autori", true )
+    );
+}
+
+$documenti = array_filter($documenti, "filter_my_documents");
 
 $args = array(
     'author' =>  $author_id,
@@ -296,6 +319,32 @@ $posts = get_posts($args);
                                                         <div class="card-icon-content">
                                                             <p>
                                                                 <strong><a href="<?php echo get_permalink($doc); ?>" ><?php echo $doc->post_title; ?></a></strong>
+                                                            </p>
+                                                        </div><!-- /card-icon-content -->
+                                                    </div><!-- /card-body -->
+                                                </div><!-- /card card-bg card-icon rounded -->
+                                            <?php } ?>
+                                        </div><!-- /card-deck card-deck-spaced -->
+                                    </div><!-- /col-lg-12 -->
+                                </div><!-- /row -->
+                            <?php }
+
+                            if (is_array($strutture) && count($strutture) > 0) {
+                                ?>
+                                <h4 id="art-par-documenti"  class="mb-4"><?php _e("Strutture", "design_scuole_italia"); ?></h4>
+                                <div class="row variable-gutters mb-4">
+                                    <div class="col-lg-12">
+                                        <div class="card-deck card-deck-spaced">
+                                            <?php foreach ($strutture as $struttura) { ?>
+                                                <div class="card card-bg card-icon rounded">
+                                                    <div class="card-body">
+                                                        <svg class="icon it-pdf-document">
+                                                            <use xmlns:xlink="http://www.w3.org/1999/xlink"
+                                                                xlink:href="#svg-school"></use>
+                                                        </svg>
+                                                        <div class="card-icon-content">
+                                                            <p>
+                                                                <strong><a href="<?php echo get_permalink($struttura); ?>" ><?php echo $struttura->post_title; ?></a></strong>
                                                             </p>
                                                         </div><!-- /card-icon-content -->
                                                     </div><!-- /card-body -->


### PR DESCRIPTION
Nella pagina personale ora sono visibili le strutture sia di cui si è responsabili (che prima non erano visibili) sia di cui si fa parte come persone.
## Descrizione
Ho modificato una parte del codice (una funzione) che filtra le strutture di cui fai parte, creato una parte nuova in cui vengono filtrate le strutture di cui si è responsabili e infine ho unito i due array che ho estrapolato per farlo comparire nella pagina personale senza dove modificare la parte successiva
## Checklist
- [ x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).
- In allegato la parte modificata e creata nuova
[Author.php.txt](https://github.com/italia/design-scuole-wordpress-theme/files/11367096/Author.php.txt)
