### PR TITLE
Update author.php

### DIFF
--- a/author.php
+++ b/author.php
@@ -124,9 +124,8 @@ $args = array(
     'posts_per_page' => -1,
     'post_type' => 'struttura'
 );
-$strutture = get_posts($args);
-
-function filter_my_structures($structure)
+$strutturememb = get_posts($args);
+function filter_my_structures_memb($structure)
 {
     if (is_array(get_post_meta($structure->ID, "_dsi_struttura_persone", true)) && !empty(get_post_meta($structure->ID, "_dsi_struttura_persone", true))) {
         return in_array(
@@ -136,8 +135,27 @@ function filter_my_structures($structure)
     }
     return false;
 }
+$strutturememb = array_filter($strutturememb, "filter_my_structures_memb");
 
-$strutture = array_filter($strutture, "filter_my_structures");
+$args = array(
+    'posts_per_page' => -1,
+    'post_type' => 'struttura'
+);
+$struttureresp = get_posts($args);
+
+function filter_my_structures_resp($structure)
+{
+    if (is_array(get_post_meta($structure->ID, "_dsi_struttura_responsabile", true)) && !empty(get_post_meta($structure->ID, "_dsi_struttura_responsabile", true))) {
+        return in_array(
+            (string)$GLOBALS['author_id'],
+            get_post_meta($structure->ID, "_dsi_struttura_responsabile", true)
+        );
+    }
+    return false;
+}
+$struttureresp = array_filter($struttureresp, "filter_my_structures_resp");
+
+$strutture = array_merge($struttureresp, $strutturememb);
 
 $args = array(
     'posts_per_page' => -1,


### PR DESCRIPTION
Nella sezione delle strutture sono ora visibili sia le strutture di cui si fa parte come persona sia quelle di cui si è responsabili.

## Descrizione
Ho modificato la parte in cui si filtravano le strutture di cui si fa parte come "persone" rinominando la funzione e l'array che viene creato strutturememb; ho creato la stessa funzione e array rispettivo per filtrare e strutture di cui si fa parte come "responsabili"; ho unito i due array nell'array strutture che è quello che vene usato in seguito per la creazione della pagina personale.
## Checklist
- [ x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).