### PR TITLE
Sostituito load delle mappe da jQuery a evento nativo load

### DIFF
--- a/archive-luogo.php
+++ b/archive-luogo.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The template for displaying archive
  *
@@ -11,159 +12,162 @@ get_header();
 global $luogo, $tipologia_luogo;
 $mappa_primo_piano = dsi_get_option("posizione_mappa", "luoghi") === 'true' ? true : false;
 ?>
-    <main id="main-container" class="main-container redbrown">
-        <?php get_template_part("template-parts/common/breadcrumb"); ?>
+<main id="main-container" class="main-container redbrown">
+    <?php get_template_part("template-parts/common/breadcrumb"); ?>
 
-        <?php get_template_part("template-parts/hero/luoghi"); ?>
+    <?php get_template_part("template-parts/hero/luoghi"); ?>
 
-        <?php
-        if($mappa_primo_piano) {
-            // recupero la lista delle tipologie
-            $i=0;
-            $locations = [];
-            $strutture_luoghi = dsi_get_option("strutture_luoghi", "luoghi");
-            if($strutture_luoghi) { ?>
-                <section class="section bg-white section-map-wrapper">
-                    <div class="map-aside">
-                        <?php foreach ($strutture_luoghi as $id_tipologia_luogo) {
+    <?php
+    if ($mappa_primo_piano) {
+        // recupero la lista delle tipologie
+        $i = 0;
+        $locations = [];
+        $strutture_luoghi = dsi_get_option("strutture_luoghi", "luoghi");
+        if ($strutture_luoghi) { ?>
+            <section class="section bg-white section-map-wrapper">
+                <div class="map-aside">
+                    <?php foreach ($strutture_luoghi as $id_tipologia_luogo) {
 
-                            $tipologia_luogo = get_term_by("id", $id_tipologia_luogo, "tipologia-luogo");
-                            if (!is_wp_error($tipologia_luogo)) {
-                                $luoghi = get_posts("post_type=luogo&tipologia-luogo=" . $tipologia_luogo->slug . "&posts_per_page=-1&orderby=post_parent&order=ASC");
-                                if (is_array($luoghi) && count($luoghi) > 0) {
-                                    ?>
-                                    <h2 class="h3">
+                        $tipologia_luogo = get_term_by("id", $id_tipologia_luogo, "tipologia-luogo");
+                        if (!is_wp_error($tipologia_luogo)) {
+                            $luoghi = get_posts("post_type=luogo&tipologia-luogo=" . $tipologia_luogo->slug . "&posts_per_page=-1&orderby=post_parent&order=ASC");
+                            if (is_array($luoghi) && count($luoghi) > 0) {
+                    ?>
+                                <h2 class="h3">
                                     <?php if (is_array($luoghi) && count($luoghi) > 1) {
                                         echo dsi_pluralize_string($tipologia_luogo->name);
                                     } else {
                                         echo $tipologia_luogo->name;
                                     } ?>
-                                    </h2>
-                                    <?php
-                                    foreach ($luoghi as $luogo) {
-                                        get_template_part("template-parts/luogo/card", "ico");
-                                    }
+                                </h2>
+                    <?php
+                                foreach ($luoghi as $luogo) {
+                                    get_template_part("template-parts/luogo/card", "ico");
                                 }
                             }
-                        } ?>
-                    </div>
-                    <div class="map-wrapper">
-                        <div class="map" id="map"></div>
-                    </div>
-                </section>
-                <!-- /section -->
-                <?php
+                        }
+                    } ?>
+                </div>
+                <div class="map-wrapper">
+                    <div class="map" id="map"></div>
+                </div>
+            </section>
+            <!-- /section -->
+        <?php
 
-                foreach ($locations as $location_key => $value) {
-                    foreach ($value as $place_key => $place) {
-                        if(!$place['lat'] || !$place['lng']) {
-                            $pos = dsi_multi_array_search($place['indirizzo'], $locations);
-                            if($pos) {
-                                $locations[$pos][] = $place;
-                                unset($locations[$location_key][$place_key]);
-                                if(empty($locations[$location_key])) unset($locations[$location_key]);
-                            }
+            foreach ($locations as $location_key => $value) {
+                foreach ($value as $place_key => $place) {
+                    if (!$place['lat'] || !$place['lng']) {
+                        $pos = dsi_multi_array_search($place['indirizzo'], $locations);
+                        if ($pos) {
+                            $locations[$pos][] = $place;
+                            unset($locations[$location_key][$place_key]);
+                            if (empty($locations[$location_key])) unset($locations[$location_key]);
                         }
                     }
                 }
-
-                $locations = array_reverse($locations);
-                $first = $locations[0];
             }
-            ?>
-            <script>
-                jQuery(function() {
-                    var mymap = L.map('map', {
-                        zoomControl: true,
-                        scrollWheelZoom: false
-                    }).setView([<?php echo $first[0]['lat'] ?>, <?php echo $first[0]['lng'] ?>], 13);
 
-                    let marker;
-                    <?php
-                    if (is_array($locations) && count($locations) > 0) {  
-                        // set markers is $location is not empty
-                        $markers = [];
-                        foreach ($locations as $location) {
-                        $title = $links =[];
+            $locations = array_reverse($locations);
+            $first = $locations[0];
+        }
+        ?>
+        <script>
+            window.addEventListener('load', function() {
+                var mymap = L.map('map', {
+                    zoomControl: true,
+                    scrollWheelZoom: false
+                }).setView([<?php echo $first[0]['lat'] ?>, <?php echo $first[0]['lng'] ?>], 13);
+
+                let marker;
+                <?php
+                if (is_array($locations) && count($locations) > 0) {
+                    // set markers is $location is not empty
+                    $markers = [];
+                    foreach ($locations as $location) {
+                        $title = $links = [];
                         foreach ($location as $place) {
-                            if($place['lat'] && $place['lng']) {
+                            if ($place['lat'] && $place['lng']) {
                                 $lat = $place['lat'];
                                 $lng = $place['lng'];
                                 $indirizzo = $place['indirizzo'];
                             }
                             $title[] = addslashes($place['title']);
-                            $links[] = '<b><a href="'.$place['permalink'].'">'.addslashes($place['title']).'</a></b>';
+                            $links[] = '<b><a href="' . $place['permalink'] . '">' . addslashes($place['title']) . '</a></b>';
                         }
                         $markers[] = '[' . $lat . "," . $lng . ']'; ?>
-                        marker = L.marker([<?php echo $lat; ?>, <?php echo $lng; ?>, {title: '<?php echo implode("-", $title); ?>'}]).addTo(mymap);
+                        marker = L.marker([<?php echo $lat; ?>, <?php echo $lng; ?>, {
+                            title: '<?php echo implode("-", $title); ?>'
+                        }]).addTo(mymap);
                         marker.bindPopup('<?php echo implode(", ", $links) ?><br><?php echo addslashes($indirizzo); ?>');
-                        <?php
-                        }
-                    }?>
+                <?php
+                    }
+                } ?>
 
-                    // add the OpenStreetMap tiles
-                    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                        attribution: '',
-                        maxZoom: 18,
-                    }).addTo(mymap);
+                // add the OpenStreetMap tiles
+                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    attribution: '',
+                    maxZoom: 18,
+                }).addTo(mymap);
 
-                    var arrayOfMarkers = [<?php echo implode(",", $markers); ?>];
-                    var bounds = new L.LatLngBounds(arrayOfMarkers);
-                    mymap.fitBounds(bounds);
-                });
-            </script><?php
-        } else {
-            // recupero la lista delle tipologie
-            $i=0;
-            $strutture_luoghi = dsi_get_option("strutture_luoghi", "luoghi");
-            if($strutture_luoghi) {
-                foreach ($strutture_luoghi as $id_tipologia_luogo) {
+                var arrayOfMarkers = [<?php echo implode(",", $markers); ?>];
+                var bounds = new L.LatLngBounds(arrayOfMarkers);
+                mymap.fitBounds(bounds);
+            });
+        </script><?php
+                } else {
+                    // recupero la lista delle tipologie
+                    $i = 0;
+                    $strutture_luoghi = dsi_get_option("strutture_luoghi", "luoghi");
+                    if ($strutture_luoghi) {
+                        foreach ($strutture_luoghi as $id_tipologia_luogo) {
 
-                    $tipologia_luogo = get_term_by("id", $id_tipologia_luogo, "tipologia-luogo");
-                    if (!is_wp_error($tipologia_luogo)) {
-                        $luoghi = get_posts("post_type=luogo&tipologia-luogo=" . $tipologia_luogo->slug . "&posts_per_page=-1&orderby=post_parent&order=ASC");
-                        if (is_array($luoghi) && count($luoghi) > 0) {
-                        $i++;
-                        $classcolor = "bg-white";
-                        if ($i % 2)
-                            $classcolor = "bg-gray-light";
+                            $tipologia_luogo = get_term_by("id", $id_tipologia_luogo, "tipologia-luogo");
+                            if (!is_wp_error($tipologia_luogo)) {
+                                $luoghi = get_posts("post_type=luogo&tipologia-luogo=" . $tipologia_luogo->slug . "&posts_per_page=-1&orderby=post_parent&order=ASC");
+                                if (is_array($luoghi) && count($luoghi) > 0) {
+                                    $i++;
+                                    $classcolor = "bg-white";
+                                    if ($i % 2)
+                                        $classcolor = "bg-gray-light";
 
-                        ?>
-                            <section class="section <?php echo $classcolor; ?> py-4">
-                                <div class="container">
-                                    <?php
+                    ?>
+                        <section class="section <?php echo $classcolor; ?> py-4">
+                            <div class="container">
+                                <?php
                                     if (is_array($luoghi) && count($luoghi) > 0) {
-                                        ?>
+                                ?>
 
-                                        <div class="row variable-gutters mt-4">
-                                            <div class="col-lg-10 offset-lg-1 mb-4">
-                                                <h4 class="text-left mb-3">
-                                                    <a href="<?php echo get_term_link($tipologia_luogo); ?>"><?php if (is_array($luoghi) && count($luoghi) > 1) echo dsi_pluralize_string($tipologia_luogo->name); else echo $tipologia_luogo->name; ?></a>
-                                                </h4>
-                                            </div><!-- /col-lg-10 -->
+                                    <div class="row variable-gutters mt-4">
+                                        <div class="col-lg-10 offset-lg-1 mb-4">
+                                            <h4 class="text-left mb-3">
+                                                <a href="<?php echo get_term_link($tipologia_luogo); ?>"><?php if (is_array($luoghi) && count($luoghi) > 1) echo dsi_pluralize_string($tipologia_luogo->name);
+                                                                                                            else echo $tipologia_luogo->name; ?></a>
+                                            </h4>
+                                        </div><!-- /col-lg-10 -->
 
-                                            <div class="col-lg-10 offset-lg-1">
-                                                <div class="row variable-gutters">
-                                                    <?php foreach ($luoghi as $luogo) { ?>
-                                                        <div class="col-lg-4 mb-4">
-                                                            <?php get_template_part("template-parts/luogo/card", "ico"); ?>
-                                                        </div><!-- /col-lg-4 -->
-                                                    <?php } ?>
-                                                </div><!-- /row -->
-                                            </div><!-- /col-lg-9 -->
-                                        </div><!-- /row -->
-                                        <?php
+                                        <div class="col-lg-10 offset-lg-1">
+                                            <div class="row variable-gutters">
+                                                <?php foreach ($luoghi as $luogo) { ?>
+                                                    <div class="col-lg-4 mb-4">
+                                                        <?php get_template_part("template-parts/luogo/card", "ico"); ?>
+                                                    </div><!-- /col-lg-4 -->
+                                                <?php } ?>
+                                            </div><!-- /row -->
+                                        </div><!-- /col-lg-9 -->
+                                    </div><!-- /row -->
+                                <?php
                                     }
-                                    ?>
-                                </div><!-- /container -->
-                            </section><!-- /section -->
-                            <?php
+                                ?>
+                            </div><!-- /container -->
+                        </section><!-- /section -->
+    <?php
+                                }
+                            }
                         }
                     }
-                }
-            }
-        } ?>
+                } ?>
 
-    </main>
+</main>
 <?php
 get_footer();

--- a/template-parts/list/article-luogo.php
+++ b/template-parts/list/article-luogo.php
@@ -1,7 +1,7 @@
 <?php
 global $post;
 $image_url = false;
-if(has_post_thumbnail($post))
+if (has_post_thumbnail($post))
     $image_url = get_the_post_thumbnail_url($post, "article-simple-thumb");
 $class = dsi_get_post_types_color_class($post->post_type);
 $icon = dsi_get_post_types_icon_class($post->post_type);
@@ -9,7 +9,7 @@ $icon = dsi_get_post_types_icon_class($post->post_type);
 
 $excerpt =  dsi_get_meta("descrizione_breve", "", $post->ID);
 
-if(!$excerpt)
+if (!$excerpt)
     $excerpt = get_the_excerpt($post);
 
 // $argomenti = dsi_get_tipologia_luogo_of_post($post);
@@ -17,34 +17,36 @@ if(!$excerpt)
 
 $posizione_gps = false;
 
-	if ( $post->post_parent == 0 ) {
-		$posizione_gps = dsi_get_meta( "posizione_gps", '_dsi_luogo_', $post->ID );
-	} else {
-		$parent        = get_post( $post->post_parent );
-		$posizione_gps = dsi_get_meta( "posizione_gps", "_dsi_luogo_", $post->post_parent );
-	}
+if ($post->post_parent == 0) {
+    $posizione_gps = dsi_get_meta("posizione_gps", '_dsi_luogo_', $post->ID);
+} else {
+    $parent        = get_post($post->post_parent);
+    $posizione_gps = dsi_get_meta("posizione_gps", "_dsi_luogo_", $post->post_parent);
+}
 
-	if($image_url)
-	    $posizione_gps = false;
+if ($image_url)
+    $posizione_gps = false;
 ?>
 <a class="presentation-card-link" href="<?php the_permalink(); ?>">
-<article class="card card-bg card-article card-article-<?php echo $class; ?> cursorhand" >
-	<div class="card-body">
-		<div class="card-article-img"  <?php if($image_url && !$posizione_gps) echo 'style="background-image: url(\''.$image_url.'\');"'; ?>>
-            <?php if($posizione_gps != false){ ?>
+    <article class="card card-bg card-article card-article-<?php echo $class; ?> cursorhand">
+        <div class="card-body">
+            <div class="card-article-img" <?php if ($image_url && !$posizione_gps) echo 'style="background-image: url(\'' . $image_url . '\');"'; ?>>
+                <?php if ($posizione_gps != false) { ?>
 
                     <div class="map-wrapper">
                         <div class="map" id="map_<?php echo $post->ID; ?>"></div>
                     </div>
-            <?php } ?>
-            <?php if(!$image_url){ ?>
-                <svg class="icon-<?php echo $class; ?> svg-<?php echo $icon; ?>"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-<?php echo $icon; ?>"></use></svg>
-            <?php } ?>
-        </div>
-		<div class="card-article-content">
-            <h2 class="h3"><?php the_title(); ?></h2>
-			<p><?php echo $excerpt; ?></p>
-            <?php /* if(is_array($argomenti) && count($argomenti)) { ?>
+                <?php } ?>
+                <?php if (!$image_url) { ?>
+                    <svg class="icon-<?php echo $class; ?> svg-<?php echo $icon; ?>">
+                        <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-<?php echo $icon; ?>"></use>
+                    </svg>
+                <?php } ?>
+            </div>
+            <div class="card-article-content">
+                <h2 class="h3"><?php the_title(); ?></h2>
+                <p><?php echo $excerpt; ?></p>
+                <?php /* if(is_array($argomenti) && count($argomenti)) { ?>
 			<div class="badges">
 				<?php foreach ( $argomenti as $item ) { ?>
                     <a href="<?php echo get_term_link($item); ?>" title="<?php _e("Vai all'argomento", "design_scuole_italia"); ?>: <?php echo $item->name; ?>"
@@ -52,13 +54,13 @@ $posizione_gps = false;
 				<?php } ?>
 			</div><!-- /badges -->
             <?php } */ ?>
-		</div><!-- /card-avatar-content -->
-	</div><!-- /card-body -->
-</article><!-- /card card-bg card-article -->
+            </div><!-- /card-avatar-content -->
+        </div><!-- /card-body -->
+    </article><!-- /card card-bg card-article -->
 </a>
-<?php if($posizione_gps != false){ ?>
+<?php if ($posizione_gps != false) { ?>
     <script>
-        jQuery(function() {
+        window.addEventListener('load', function() {
             var mymap = L.map('map_<?php echo $post->ID; ?>', {
                 zoomControl: false,
                 scrollWheelZoom: false

--- a/template-parts/luogo/card-custom.php
+++ b/template-parts/luogo/card-custom.php
@@ -1,15 +1,15 @@
 <?php
 global $post;
-$c=0;
+$c = 0;
 
 $nome_luogo_custom = dsi_get_meta("nome_luogo_custom");
 $posizione_gps =  dsi_get_meta("posizione_gps_luogo_custom");
 $indirizzo_luogo_custom = dsi_get_meta("indirizzo_luogo_custom");
 $arrq = array();
-if(dsi_get_meta("quartiere_luogo_custom") != "")
-	$arrq[]=dsi_get_meta("quartiere_luogo_custom");
-if(dsi_get_meta("circoscrizione_luogo_custom") != "")
-	$arrq[]=dsi_get_meta("circoscrizione_luogo_custom");
+if (dsi_get_meta("quartiere_luogo_custom") != "")
+	$arrq[] = dsi_get_meta("quartiere_luogo_custom");
+if (dsi_get_meta("circoscrizione_luogo_custom") != "")
+	$arrq[] = dsi_get_meta("circoscrizione_luogo_custom");
 ?>
 
 <div class="card card-bg rounded mb-5">
@@ -30,18 +30,18 @@ if(dsi_get_meta("circoscrizione_luogo_custom") != "")
 </div><!-- /card card-bg rounded -->
 
 <script>
-    jQuery(function() {
-        var mymap = L.map('map_<?php echo $c; ?>', {
-            zoomControl: false,
-            scrollWheelZoom: false
-        }).setView([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>], 15);
+	window.addEventListener('load', function() {
+		var mymap = L.map('map_<?php echo $c; ?>', {
+			zoomControl: false,
+			scrollWheelZoom: false
+		}).setView([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>], 15);
 
-        L.marker([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>]).addTo(mymap);
+		L.marker([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>]).addTo(mymap);
 
-        // add the OpenStreetMap tiles
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '',
-            maxZoom: 18,
-        }).addTo(mymap);
-    });
+		// add the OpenStreetMap tiles
+		L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+			attribution: '',
+			maxZoom: 18,
+		}).addTo(mymap);
+	});
 </script>

--- a/template-parts/luogo/card-large.php
+++ b/template-parts/luogo/card-large.php
@@ -2,14 +2,14 @@
 global $luogo, $struttura, $c;
 
 // controllo se è un parent, in caso recupero i dati del genitore
-if($luogo->post_parent == 0){
+if ($luogo->post_parent == 0) {
 	$card_title = $luogo->post_title;
 	$indirizzo = dsi_get_meta("indirizzo", '_dsi_luogo_', $luogo->ID);
 	$posizione_gps = dsi_get_meta("posizione_gps", '_dsi_luogo_', $luogo->ID);
 	$cap = dsi_get_meta("cap", '_dsi_luogo_', $luogo->ID);
 	$mail = dsi_get_meta("mail", '_dsi_luogo_', $luogo->ID);
 	$telefono = dsi_get_meta("telefono", '_dsi_luogo_', $luogo->ID);
-}else{
+} else {
 	$parent = get_post($luogo->post_parent);
 	$card_title = $parent->post_title;
 	$indirizzo = dsi_get_meta("indirizzo", "_dsi_luogo_", $luogo->post_parent);
@@ -21,39 +21,38 @@ if($luogo->post_parent == 0){
 
 $orario_pubblico = dsi_get_meta("orario_pubblico", '_dsi_luogo_', $luogo->ID);
 
-if(isset($struttura->ID) && dsi_get_meta("telefono", '_dsi_struttura_', $struttura->ID) != "")
+if (isset($struttura->ID) && dsi_get_meta("telefono", '_dsi_struttura_', $struttura->ID) != "")
 	$telefono = dsi_get_meta("telefono", '_dsi_struttura_', $struttura->ID);
 
-if(isset($struttura->ID) && dsi_get_meta("mail", '_dsi_struttura_', $struttura->ID) != "")
+if (isset($struttura->ID) && dsi_get_meta("mail", '_dsi_struttura_', $struttura->ID) != "")
 	$mail = dsi_get_meta("mail", '_dsi_struttura_', $struttura->ID);
 
-if(isset($struttura->ID) && dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID) != "")
+if (isset($struttura->ID) && dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID) != "")
 	$pec = dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID);
 
-if(isset($struttura->ID)){
+if (isset($struttura->ID)) {
 	$arr_persone = dsi_get_meta("persone", '_dsi_struttura_', $struttura->ID);
 	$persone = "";
-	if(is_array($arr_persone)){
-		foreach ($arr_persone as $id_persona){
+	if (is_array($arr_persone)) {
+		foreach ($arr_persone as $id_persona) {
 			//$utente = get_user_by("id", $id_persona);
-			$persone .= dsi_get_display_name($id_persona)." ";
+			$persone .= dsi_get_display_name($id_persona) . " ";
 		}
 	}
-
 }
 ?>
 <div class="card card-bg rounded mb-5">
 	<div class="card-header">
-        <?php if(is_singular("luogo") && ($luogo->post_parent == 0)){ ?>
-            <strong class="d-block"><?php echo $card_title; ?></strong>
-        <?php }else if(is_singular("luogo") && ($luogo->post_parent > 0)){
-            // sono nel luogo child, stampo il nome e il link del parent
-            ?>
-            <a href="<?php echo get_permalink($luogo->post_parent); ?>"><strong class="d-block"><?php echo get_the_title($luogo->post_parent); ?></strong></a>
-            <?php
-        } else { ?>
-            <a href="<?php echo get_permalink($luogo); ?>"><strong class="d-block"><?php echo $card_title; ?></strong></a>
-        <?php } ?>
+		<?php if (is_singular("luogo") && ($luogo->post_parent == 0)) { ?>
+			<strong class="d-block"><?php echo $card_title; ?></strong>
+		<?php } else if (is_singular("luogo") && ($luogo->post_parent > 0)) {
+			// sono nel luogo child, stampo il nome e il link del parent
+		?>
+			<a href="<?php echo get_permalink($luogo->post_parent); ?>"><strong class="d-block"><?php echo get_the_title($luogo->post_parent); ?></strong></a>
+		<?php
+		} else { ?>
+			<a href="<?php echo get_permalink($luogo); ?>"><strong class="d-block"><?php echo $card_title; ?></strong></a>
+		<?php } ?>
 
 		<small class="d-block"><?php echo wpautop($indirizzo); ?></small>
 		<!-- <small class="d-block">Quartiere Tufello - 4° Circoscrizione</small> //-->
@@ -71,17 +70,17 @@ if(isset($struttura->ID)){
 
 
 <script>
-    jQuery(function() {
-        var mymap = L.map('map_<?php echo $c; ?>', {
-            zoomControl: false,
-            scrollWheelZoom: false
-        }).setView([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>], 15);
-        L.marker([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>]).addTo(mymap);
+	window.addEventListener('load', function() {
+		var mymap = L.map('map_<?php echo $c; ?>', {
+			zoomControl: false,
+			scrollWheelZoom: false
+		}).setView([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>], 15);
+		L.marker([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>]).addTo(mymap);
 
-        // add the OpenStreetMap tiles
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '',
-            maxZoom: 18,
-        }).addTo(mymap);
-    });
+		// add the OpenStreetMap tiles
+		L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+			attribution: '',
+			maxZoom: 18,
+		}).addTo(mymap);
+	});
 </script>

--- a/template-parts/luogo/card-nophone.php
+++ b/template-parts/luogo/card-nophone.php
@@ -3,15 +3,15 @@ global $luogo, $struttura, $c;
 
 
 // controllo se è un parent, in caso recupero i dati del genitore
-if($luogo->post_parent == 0){
+if ($luogo->post_parent == 0) {
 	$card_title = $luogo->post_title;
 	$indirizzo = dsi_get_meta("indirizzo", '_dsi_luogo_', $luogo->ID);
 	$posizione_gps = dsi_get_meta("posizione_gps", '_dsi_luogo_', $luogo->ID);
 	$cap = dsi_get_meta("cap", '_dsi_luogo_', $luogo->ID);
 	//$mail = dsi_get_meta("mail", '_dsi_luogo_', $luogo->ID);
 	//$telefono = dsi_get_meta("telefono", '_dsi_luogo_', $luogo->ID);
-}else{
-    $parent = get_post($luogo->post_parent);
+} else {
+	$parent = get_post($luogo->post_parent);
 	$card_title = $parent->post_title;
 	$indirizzo = dsi_get_meta("indirizzo", "_dsi_luogo_", $luogo->post_parent);
 	$posizione_gps = dsi_get_meta("posizione_gps", "_dsi_luogo_", $luogo->post_parent);
@@ -31,15 +31,14 @@ if(isset($struttura->ID) && dsi_get_meta("mail", '_dsi_struttura_', $struttura->
 if(isset($struttura->ID) && dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID) != "")
 	$pec = dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID);
 */
-if(isset($struttura->ID)){
+if (isset($struttura->ID)) {
 	$arr_persone = dsi_get_meta("persone", '_dsi_struttura_', $struttura->ID);
 	$persone = "";
-	if(is_array($arr_persone)){
-		foreach ($arr_persone as $id_persona){
-			$persone .= dsi_get_display_name($id_persona)." ";
+	if (is_array($arr_persone)) {
+		foreach ($arr_persone as $id_persona) {
+			$persone .= dsi_get_display_name($id_persona) . " ";
 		}
-    }
-
+	}
 }
 ?>
 
@@ -47,11 +46,11 @@ if(isset($struttura->ID)){
 	<div class="col-lg-9">
 		<div class="card card-bg rounded mb-5">
 			<div class="card-header">
-                <?php if(is_singular("luogo")){ ?>
-                    <strong><?php echo $card_title; ?></strong>
-                <?php }else { ?>
-                    <a href="<?php echo get_permalink($luogo); ?>"><strong><?php echo $luogo->post_title; ?></strong></a>
-	            <?php } ?>
+				<?php if (is_singular("luogo")) { ?>
+					<strong><?php echo $card_title; ?></strong>
+				<?php } else { ?>
+					<a href="<?php echo get_permalink($luogo); ?>"><strong><?php echo $luogo->post_title; ?></strong></a>
+				<?php } ?>
 			</div><!-- /card-header -->
 			<div class="card-body p-0">
 				<div class="row variable-gutters">
@@ -63,30 +62,30 @@ if(isset($struttura->ID)){
 					<div class="col-lg-7">
 						<div class="py-4">
 							<ul class="location-list mt-2">
-								<?php if(isset($indirizzo) && $indirizzo != ""){ ?>
+								<?php if (isset($indirizzo) && $indirizzo != "") { ?>
 									<li>
 										<div class="location-title">
-											<span><?php _e( "indirizzo", "design_scuole_italia" ); ?></span>
+											<span><?php _e("indirizzo", "design_scuole_italia"); ?></span>
 										</div>
 										<div class="location-content">
 											<?php echo wpautop($indirizzo); ?>
 										</div>
 									</li>
 								<?php } ?>
-								<?php if(isset($cap) && $cap != ""){ ?>
+								<?php if (isset($cap) && $cap != "") { ?>
 									<li>
 										<div class="location-title">
-											<span><?php _e( "CAP", "design_scuole_italia" ); ?></span>
+											<span><?php _e("CAP", "design_scuole_italia"); ?></span>
 										</div>
 										<div class="location-content">
 											<p><?php echo $cap; ?></p>
 										</div>
 									</li>
 								<?php } ?>
-								<?php if(isset($orario_pubblico) && $orario_pubblico != ""){ ?>
+								<?php if (isset($orario_pubblico) && $orario_pubblico != "") { ?>
 									<li>
 										<div class="location-title">
-											<span><?php _e( "Orari", "design_scuole_italia" ); ?></span>
+											<span><?php _e("Orari", "design_scuole_italia"); ?></span>
 										</div>
 										<div class="location-content">
 											<?php echo wpautop($orario_pubblico); ?>
@@ -125,10 +124,10 @@ if(isset($struttura->ID)){
 										</div>
 									</li>
 								<?php } */ ?>
-								<?php if(isset($persone) && $persone != ""){ ?>
+								<?php if (isset($persone) && $persone != "") { ?>
 									<li>
 										<div class="location-title">
-											<span><?php _e( "Rif.", "design_scuole_italia" ); ?></span>
+											<span><?php _e("Rif.", "design_scuole_italia"); ?></span>
 										</div>
 										<div class="location-content">
 											<p><?php echo $persone; ?></p>
@@ -144,17 +143,17 @@ if(isset($struttura->ID)){
 	</div><!-- /col-lg-9 -->
 </div><!-- /row -->
 <script>
-    jQuery(function() {
-        var mymap = L.map('map_<?php echo $c; ?>', {
-            zoomControl: false,
-            scrollWheelZoom: false
-        }).setView([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>], 15);
-        L.marker([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>]).addTo(mymap);
+	window.addEventListener('load', function() {
+		var mymap = L.map('map_<?php echo $c; ?>', {
+			zoomControl: false,
+			scrollWheelZoom: false
+		}).setView([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>], 15);
+		L.marker([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>]).addTo(mymap);
 
-        // add the OpenStreetMap tiles
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '',
-            maxZoom: 18,
-        }).addTo(mymap);
-    });
+		// add the OpenStreetMap tiles
+		L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+			attribution: '',
+			maxZoom: 18,
+		}).addTo(mymap);
+	});
 </script>

--- a/template-parts/luogo/card.php
+++ b/template-parts/luogo/card.php
@@ -1,14 +1,14 @@
 <?php
 global $luogo, $struttura, $c, $lg;
 
-if(!$lg) $lg = 9;
+if (!$lg) $lg = 9;
 
-if($lg == 9){
-    $col1=5;
-    $col2=7;
-}else{
-    $col1=6;
-    $col2=6;
+if ($lg == 9) {
+	$col1 = 5;
+	$col2 = 7;
+} else {
+	$col1 = 6;
+	$col2 = 6;
 }
 
 $card_title = $luogo->post_title;
@@ -20,42 +20,40 @@ $pec = dsi_get_meta("pec", '_dsi_luogo_', $luogo->ID);
 $telefono = dsi_get_meta("telefono", '_dsi_luogo_', $luogo->ID);
 
 // controllo se è un parent, in caso recupero i dati del genitore
-if($luogo->post_parent == 0){
-	
-}else{
+if ($luogo->post_parent == 0) {
+} else {
 	$parent = get_post($luogo->post_parent);
 	$card_title = $parent->post_title;
-	if(!$indirizzo)	$indirizzo = dsi_get_meta("indirizzo", "_dsi_luogo_", $luogo->post_parent);
-	if(!$posizione_gps["lat"] || !$posizione_gps["lng"]) $posizione_gps = dsi_get_meta("posizione_gps", "_dsi_luogo_", $luogo->post_parent);
-	if(!$cap) $cap = dsi_get_meta("cap", "_dsi_luogo_", $luogo->post_parent);
-	if(!$mail) $mail = dsi_get_meta("mail", "_dsi_luogo_", $luogo->post_parent);
-	if(!$pec) $pec = dsi_get_meta("pec", "_dsi_luogo_", $luogo->post_parent);
-	if(!$telefono) $telefono = dsi_get_meta("telefono", "_dsi_luogo_", $luogo->post_parent);
+	if (!$indirizzo)  $indirizzo = dsi_get_meta("indirizzo", "_dsi_luogo_", $luogo->post_parent);
+	if (!$posizione_gps["lat"] || !$posizione_gps["lng"]) $posizione_gps = dsi_get_meta("posizione_gps", "_dsi_luogo_", $luogo->post_parent);
+	if (!$cap) $cap = dsi_get_meta("cap", "_dsi_luogo_", $luogo->post_parent);
+	if (!$mail) $mail = dsi_get_meta("mail", "_dsi_luogo_", $luogo->post_parent);
+	if (!$pec) $pec = dsi_get_meta("pec", "_dsi_luogo_", $luogo->post_parent);
+	if (!$telefono) $telefono = dsi_get_meta("telefono", "_dsi_luogo_", $luogo->post_parent);
 }
 
 $orario_pubblico = dsi_get_meta("orario_pubblico", '_dsi_luogo_', $luogo->ID);
 
-if(isset($struttura->ID) && dsi_get_meta("telefono", '_dsi_struttura_', $struttura->ID) != "")
+if (isset($struttura->ID) && dsi_get_meta("telefono", '_dsi_struttura_', $struttura->ID) != "")
 	$telefono = dsi_get_meta("telefono", '_dsi_struttura_', $struttura->ID);
 
-if(isset($struttura->ID) && dsi_get_meta("mail", '_dsi_struttura_', $struttura->ID) != "")
+if (isset($struttura->ID) && dsi_get_meta("mail", '_dsi_struttura_', $struttura->ID) != "")
 	$mail = dsi_get_meta("mail", '_dsi_struttura_', $struttura->ID);
 
-if(isset($struttura->ID) && dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID) != "")
-$pec = dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID);
-
-if(isset($struttura->ID) && dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID) != "")
+if (isset($struttura->ID) && dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID) != "")
 	$pec = dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID);
 
-if(isset($struttura->ID)){
+if (isset($struttura->ID) && dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID) != "")
+	$pec = dsi_get_meta("pec", '_dsi_struttura_', $struttura->ID);
+
+if (isset($struttura->ID)) {
 	$arr_persone = dsi_get_meta("persone", '_dsi_struttura_', $struttura->ID);
 	$persone = "";
-	if(is_array($arr_persone)){
-		foreach ($arr_persone as $id_persona){
-			$persone .= dsi_get_display_name( $id_persona)." ";
+	if (is_array($arr_persone)) {
+		foreach ($arr_persone as $id_persona) {
+			$persone .= dsi_get_display_name($id_persona) . " ";
 		}
-    }
-
+	}
 }
 ?>
 
@@ -63,16 +61,16 @@ if(isset($struttura->ID)){
 	<div class="col-lg-<?php echo $lg; ?>">
 		<div class="card card-bg rounded mb-5">
 			<div class="card-header">
-                <?php if(is_singular("luogo") && ($luogo->post_parent == 0)){ ?>
-                    <strong><?php echo $card_title; ?></strong>
-                <?php }else if(is_singular("luogo") && ($luogo->post_parent > 0)){
-                    // sono nel luogo child, stampo il nome e il link del parent
-                    ?>
-                    <a href="<?php echo get_permalink($luogo->post_parent); ?>"><strong><?php echo get_the_title($luogo->post_parent); ?></strong></a>
-                    <?php
-                } else { ?>
-                    <a href="<?php echo get_permalink($luogo); ?>"><strong><?php echo $luogo->post_title; ?></strong></a>
-                <?php } ?>
+				<?php if (is_singular("luogo") && ($luogo->post_parent == 0)) { ?>
+					<strong><?php echo $card_title; ?></strong>
+				<?php } else if (is_singular("luogo") && ($luogo->post_parent > 0)) {
+					// sono nel luogo child, stampo il nome e il link del parent
+				?>
+					<a href="<?php echo get_permalink($luogo->post_parent); ?>"><strong><?php echo get_the_title($luogo->post_parent); ?></strong></a>
+				<?php
+				} else { ?>
+					<a href="<?php echo get_permalink($luogo); ?>"><strong><?php echo $luogo->post_title; ?></strong></a>
+				<?php } ?>
 			</div><!-- /card-header -->
 			<div class="card-body p-0">
 				<div class="row variable-gutters">
@@ -84,50 +82,50 @@ if(isset($struttura->ID)){
 					<div class="col-lg-<?php echo $col2; ?>">
 						<div class="py-4">
 							<ul class="location-list mt-2" data-element="places">
-								<?php if(isset($indirizzo) && $indirizzo != ""){ ?>
+								<?php if (isset($indirizzo) && $indirizzo != "") { ?>
 									<li>
 										<div class="location-title">
-											<span><?php _e( "indirizzo", "design_scuole_italia" ); ?></span>
+											<span><?php _e("indirizzo", "design_scuole_italia"); ?></span>
 										</div>
 										<div class="location-content">
 											<?php echo wpautop($indirizzo); ?>
 										</div>
 									</li>
 								<?php } ?>
-								<?php if(isset($cap) && $cap != ""){ ?>
+								<?php if (isset($cap) && $cap != "") { ?>
 									<li>
 										<div class="location-title">
-											<span><?php _e( "CAP", "design_scuole_italia" ); ?></span>
+											<span><?php _e("CAP", "design_scuole_italia"); ?></span>
 										</div>
 										<div class="location-content">
 											<p><?php echo $cap; ?></p>
 										</div>
 									</li>
 								<?php } ?>
-								<?php if(isset($orario_pubblico) && $orario_pubblico != ""){ ?>
+								<?php if (isset($orario_pubblico) && $orario_pubblico != "") { ?>
 									<li>
 										<div class="location-title">
-											<span><?php _e( "Orari", "design_scuole_italia" ); ?></span>
+											<span><?php _e("Orari", "design_scuole_italia"); ?></span>
 										</div>
 										<div class="location-content">
 											<?php echo wpautop($orario_pubblico); ?>
 										</div>
 									</li>
 								<?php } ?>
-								<?php if(isset($mail) && $mail != ""){ ?>
+								<?php if (isset($mail) && $mail != "") { ?>
 									<li>
 										<div class="location-title">
-											<span><?php _e( "Email", "design_scuole_italia" ); ?></span>
+											<span><?php _e("Email", "design_scuole_italia"); ?></span>
 										</div>
 										<div class="location-content">
 											<p><a href="mailto:<?php echo $mail; ?>"><?php echo $mail; ?></a></p>
 										</div>
 									</li>
 								<?php } ?>
-								<?php if(isset($pec) && $pec != ""){ ?>
+								<?php if (isset($pec) && $pec != "") { ?>
 									<li>
 										<div class="location-title">
-											<span><?php _e( "PEC", "design_scuole_italia" ); ?></span>
+											<span><?php _e("PEC", "design_scuole_italia"); ?></span>
 										</div>
 										<div class="location-content">
 											<p><a href="mailto:<?php echo $pec; ?>"><?php echo $pec; ?></a></p>
@@ -135,35 +133,39 @@ if(isset($struttura->ID)){
 									</li>
 								<?php } ?>
 								<?php
-                                if(isset($telefono) && $telefono != ""){
-	                                ?>
+								if (isset($telefono) && $telefono != "") {
+								?>
 									<li>
 										<div class="location-title">
-											<span><?php _e( "Telefono", "design_scuole_italia" ); ?></span>
+											<span><?php _e("Telefono", "design_scuole_italia"); ?></span>
 										</div>
 										<div class="location-content">
 											<p><?php echo "<a href='tel:+39$telefono'>$telefono</a>"; ?></p>
 										</div>
 									</li>
 								<?php } ?>
-								<?php if(isset($persone) && $persone != ""){ ?>
+								<?php if (isset($persone) && $persone != "") { ?>
 									<li>
 										<div class="location-title">
-											<span><?php _e( "Rif.", "design_scuole_italia" ); ?></span>
+											<span><?php _e("Rif.", "design_scuole_italia"); ?></span>
 										</div>
 										<div class="location-content">
 											<p><?php echo $persone; ?></p>
 										</div>
 									</li>
 								<?php } ?>
-                                <li><div class="location-title">
-                                        <svg class="icon svg-marker-simple" style="width: 14px; height: 14px;"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-marker-simple"></use></svg>
-                                    </div>
-                                    <div class="location-content">
-                                        <p>
-                                            <a href="https://www.google.com/maps/dir/'<?php echo $posizione_gps["lat"]; ?>,<?php echo $posizione_gps["lng"]; ?>'/@<?php echo $posizione_gps["lat"]; ?>,<?php echo $posizione_gps["lng"]; ?>,15z?hl=it" target="_blank"><?php _e("Naviga su Google Map", "design_scuole_italia"); ?></a></p>
-                                    </div>
-                                </li>
+								<li>
+									<div class="location-title">
+										<svg class="icon svg-marker-simple" style="width: 14px; height: 14px;">
+											<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-marker-simple"></use>
+										</svg>
+									</div>
+									<div class="location-content">
+										<p>
+											<a href="https://www.google.com/maps/dir/'<?php echo $posizione_gps["lat"]; ?>,<?php echo $posizione_gps["lng"]; ?>'/@<?php echo $posizione_gps["lat"]; ?>,<?php echo $posizione_gps["lng"]; ?>,15z?hl=it" target="_blank"><?php _e("Naviga su Google Map", "design_scuole_italia"); ?></a>
+										</p>
+									</div>
+								</li>
 							</ul><!-- /location-list -->
 						</div>
 					</div><!-- /col-lg-8 -->
@@ -173,21 +175,21 @@ if(isset($struttura->ID)){
 	</div><!-- /col-lg-9 -->
 </div><!-- /row -->
 
-<?php if(!empty($posizione_gps["lat"])): ?>
-    <script>
-        jQuery(function() {
-            var mymap = L.map('map_<?php echo $c; ?>', {
-                zoomControl: false,
-                scrollWheelZoom: false
-            }).setView([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>], 15);
+<?php if (!empty($posizione_gps["lat"])) : ?>
+	<script>
+		window.addEventListener('load', function() {
+			var mymap = L.map('map_<?php echo $c; ?>', {
+				zoomControl: false,
+				scrollWheelZoom: false
+			}).setView([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>], 15);
 
-            L.marker([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>]).addTo(mymap);
+			L.marker([<?php echo $posizione_gps["lat"]; ?>, <?php echo $posizione_gps["lng"]; ?>]).addTo(mymap);
 
-            // add the OpenStreetMap tiles
-            L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-                maxZoom: 18,
-                attribution: ''
-            }).addTo(mymap);
-        });
-    </script>
+			// add the OpenStreetMap tiles
+			L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+				maxZoom: 18,
+				attribution: ''
+			}).addTo(mymap);
+		});
+	</script>
 <?php endif; ?>

--- a/template-parts/luogo/map.php
+++ b/template-parts/luogo/map.php
@@ -1,6 +1,6 @@
 <?php
 $arr_luoghi = array();
-$c=0;
+$c = 0;
 $luoghi = get_posts("post_type=luogo&posts_per_page=-1&post_parent=0");
 foreach ($luoghi as $luogo) {
     $posizione_gps = dsi_get_meta("posizione_gps", "", $luogo->ID);
@@ -14,7 +14,7 @@ foreach ($luoghi as $luogo) {
     }
 }
 
-if($c) { ?>
+if ($c) { ?>
     <section class="section section-map-full">
         <div class="container d-flex justify-content-between align-items-center py-3">
             <div class="map-wrapper">
@@ -23,17 +23,19 @@ if($c) { ?>
         </div>
     </section>
     <script>
-        jQuery(function() {
+        window.addEventListener('load', function() {
             var mymap = L.map('map_all', {
                 zoomControl: true,
                 scrollWheelZoom: false
             }).setView([<?php echo $arr_luoghi[0]["gps"]["lat"]; ?>, <?php echo $arr_luoghi[0]["gps"]["lng"]; ?>], 13);
 
             let marker;
-            <?php foreach ($arr_luoghi as $marker){ ?>
+            <?php foreach ($arr_luoghi as $marker) { ?>
 
-            marker = L.marker([<?php echo $marker["gps"]["lat"]; ?>, <?php echo $marker["gps"]["lng"]; ?>, { title: '<?php echo addslashes($marker["post_title"]); ?>'}]).addTo(mymap);
-            marker.bindPopup('<b><a href="<?php echo $marker["permalink"] ?>"><?php echo addslashes($marker["post_title"]); ?></a></b><br><?php echo addslashes($marker["indirizzo"]); ?>');
+                marker = L.marker([<?php echo $marker["gps"]["lat"]; ?>, <?php echo $marker["gps"]["lng"]; ?>, {
+                    title: '<?php echo addslashes($marker["post_title"]); ?>'
+                }]).addTo(mymap);
+                marker.bindPopup('<b><a href="<?php echo $marker["permalink"] ?>"><?php echo addslashes($marker["post_title"]); ?></a></b><br><?php echo addslashes($marker["indirizzo"]); ?>');
 
             <?php } ?>
 
@@ -43,7 +45,7 @@ if($c) { ?>
                 maxZoom: 18,
             }).addTo(mymap);
 
-            var arrayOfMarkers = [<?php foreach ($arr_luoghi as $marker){ ?> [ <?php echo $marker["gps"]["lat"]; ?>, <?php echo $marker["gps"]["lng"]; ?>], <?php } ?>];
+            var arrayOfMarkers = [<?php foreach ($arr_luoghi as $marker) { ?>[<?php echo $marker["gps"]["lat"]; ?>, <?php echo $marker["gps"]["lng"]; ?>], <?php } ?>];
             var bounds = new L.LatLngBounds(arrayOfMarkers);
             mymap.fitBounds(bounds);
         });


### PR DESCRIPTION
Corretto il caricamento delle mappe Leaflet migrando da jQuery all'evento nativo window.onload

## Descrizione

A seguito di alcune lavorazioni per l'ottimizzazione del punteggio delle pagine con lo strumento di validazione, jQuery e gli altri script sono stati resi async e defer. Ciò a impedito alle mappe nella sezione luoghi di caricare corretamente, siccome jQuery risulta undefined.
Per ovviare al problema, è bastato migrare il caricamento della mappe dal jQuery.ready all'evento nativo window.load.

## Checklist

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->