### PR TITLE
Fix visualizzazione notizie con una sola tipologia

### DIFF
--- a/template-parts/home/articoli-eventi.php
+++ b/template-parts/home/articoli-eventi.php
@@ -23,10 +23,8 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
         if($tipologia_notizia) {
             // se è selezionata solo una tipologia, pesco 2 elementi
             $ppp=1;
-            if((count($tipologie_notizie) == 1) && ($home_show_events == "false")){
+            if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
                 $ppp=2;
-                echo '<div class="row variable-gutters">';
-            }
             $args = array('post_type' => 'post',
                     'posts_per_page' => $ppp,
                     'tax_query' => array(
@@ -50,6 +48,8 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
                 </div><!-- /title-section -->
 
                 <?php
+                if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
+                    echo '<div class="row variable-gutters">';
                 foreach ($posts as $post) {
                     if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
                         echo '<div class="col-lg-6 mb-2">';


### PR DESCRIPTION
Corretta la visualizzazione delle notizie nel caso di una sola tipologia selezionata (posizione errata di un div)

<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->