### PR TITLE
Correzione nomi pagine

### DIFF
--- a/inc/activation.php
+++ b/inc/activation.php
@@ -13,7 +13,7 @@ function dsi_create_pages_on_theme_activation() {
 
 
     // template page per la scuola
-    $new_page_title    = __( 'La Scuola', 'design_scuole_italia' ); // Page's title
+    $new_page_title    = __( 'Scuola', 'design_scuole_italia' ); // Page's title
     $new_page_content  = '';                           // Content goes here
     $new_page_template = 'page-templates/la-scuola.php';       // The template to use for the page
     $page_check        = get_page_by_title( $new_page_title );   // Check if the page already exists
@@ -109,8 +109,8 @@ function dsi_create_pages_on_theme_activation() {
     }
 
 
-    // template page per Le Persone
-    $new_page_title    = __( 'Persone', 'design_scuole_italia' ); // Page's title
+    // template page per Le persone
+    $new_page_title    = __( 'Le persone', 'design_scuole_italia' ); // Page's title
     $new_page_content  = '';                           // Content goes here
     $new_page_template = 'page-templates/persone.php';       // The template to use for the page
     $page_check        = get_page_by_title( $new_page_title );   // Check if the page already exists

--- a/template-parts/hero/luoghi.php
+++ b/template-parts/hero/luoghi.php
@@ -10,7 +10,7 @@ $testo_sezione_luoghi = dsi_get_option("testo_sezione_luoghi", "luoghi");
         <div class="row variable-gutters">
             <div class="col-md-5">
                 <div class="hero-title text-left">
-                    <h1 class="p-0 mb-2"><?php _e("I luoghi della Scuola", "design_scuole_italia"); ?></h1>
+                    <h1 class="p-0 mb-2"><?php _e("I luoghi", "design_scuole_italia"); ?></h1>
                     <p class="h4 font-weight-normal"><?php echo $testo_sezione_luoghi; ?></p>
                 </div><!-- /hero-title -->
             </div><!-- /col-md-5 -->


### PR DESCRIPTION
Correzione nomi pagine per far coincidere breadcrumb con titolo del menù

<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

In seguito alle segnalazioni di un consulente di una scuola, abbiamo effettuato piccole modifiche per far coincidere titolo pagina, breadcrumb e etichetta menu.
Non risolve completamente quanto segnalato dall'issue

<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->
Fixes #395 

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->