### PR TITLE
Cambio dell'etichetta delle select delle persone

### DIFF
--- a/inc/admin/persona.php
+++ b/inc/admin/persona.php
@@ -368,7 +368,7 @@ function dsi_add_persone_metaboxes() {
 function dsi_get_cmb2_user( $query_args ) {
 
 	$args = wp_parse_args( $query_args, array(
-		'fields' => array( 'user_login' ),
+		'fields' => array( 'display_name' ),
 
 	) );
 
@@ -377,7 +377,7 @@ function dsi_get_cmb2_user( $query_args ) {
 	$user_options = array();
 	if ( $users ) {
 		foreach ( $users as $user ) {
-			$user_options[ $user->ID ] = $user->user_login;
+			$user_options[ $user->ID ] = $user->display_name;
 		}
 	}
 

--- a/inc/cmb2.php
+++ b/inc/cmb2.php
@@ -14,14 +14,14 @@ require "vendor/cmb-field-select2-master/cmb-field-select2.php";
 function dsi_get_user_options( $query_args = false) {
 
 	if(!$query_args)
-		$query_args['fields'] = array( 'ID', 'user_login' );
+		$query_args['fields'] = array( 'ID', 'display_name' );
 
 	$users = get_users( $query_args );
 
 	$user_options = array();
 	if ( $users ) {
 		foreach ( $users as $user ) {
-			$user_options[ $user->ID ] = $user->user_login;
+			$user_options[ $user->ID ] = $user->display_name;
 		}
 	}
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Impostato  il campo "Nome visualizzato" nelle select delle persone nelle interfacce del pannello di controllo.
Il comportamento, in caso il campo non venga cambiato, rimane invariato di come svolto finora.

Fixes #397 

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->