### PR TITLE
Abstract Articolo Obbligatorio

### DIFF
--- a/inc/admin/articolo.php
+++ b/inc/admin/articolo.php
@@ -42,14 +42,14 @@ function dsi_add_articolo_metaboxes() {
 	$prefix = '_dsi_articolo_';
 
 
-    $cmb_abstrat = new_cmb2_box( array(
+    $cmb_abstract = new_cmb2_box( array(
         'id'           => $prefix . 'box_abstract',
         'object_types' => array( 'post' ),
         'context'      => 'after_title',
         'priority'     => 'high',
     ) );
 
-    $cmb_abstrat->add_field( array(
+    $cmb_abstract->add_field( array(
         'id' => $prefix . 'tipologia',
         'name'        => __( 'Tipologia articolo *', 'design_scuole_italia' ),
         'type'             => 'taxonomy_radio_inline',
@@ -63,13 +63,14 @@ function dsi_add_articolo_metaboxes() {
     ) );
 
 
-    $cmb_abstrat->add_field( array(
+    $cmb_abstract->add_field( array(
         'id' => $prefix . 'descrizione',
-        'name'        => __( 'Abstract', 'design_scuole_italia' ),
+        'name'        => __( 'Abstract *', 'design_scuole_italia' ),
         'desc' => __( 'Indicare un sintetico abstract (max 160 caratteri)' , 'design_scuole_italia' ),
         'type' => 'textarea',
         'attributes'    => array(
-            'maxlength'  => '160'
+            'maxlength'  => '160',
+	    'required' => 'required'
         ),
     ) );
 


### PR DESCRIPTION
Reso obbligatorio l'abstract (descrizione breve) degli articoli, così come indicato nel documento di architettura dell’informazione (https://designers.italia.it/files/resources/modelli/scuole/adotta-il-modello-di-sito-scolastico/definisci-architettura-e-contenuti/Architettura-informazione-sito-scuole.ods).  N.B: La modifica è visibile solo lato backend e non ha effetti sugli articoli eventualmente già pubblicati in passato senza valorizzare il campo richiesto... ma impedisce la pubblicazione di quelli nuovi senza abstract. 
Corretti contestualmente anche alcuni refusi nei nomi delle funzioni (abstrat invece che abstract).

<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->