### PR TITLE
Update articoli-eventi.php

### DIFF
--- a/template-parts/home/articoli-eventi.php
+++ b/template-parts/home/articoli-eventi.php
@@ -4,8 +4,6 @@
 
 $tipologie_notizie = dsi_get_option("tipologie_notizie", "notizie");
 $home_show_events = dsi_get_option("home_show_events", "homepage");
-$giorni_per_filtro = dsi_get_option("giorni_per_filtro", "homepage");
-$data_limite_filtro = strtotime("-". $giorni_per_filtro . " day");
 
 $ct=0;
 $column = 1;
@@ -18,14 +16,17 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
     <div class="row variable-gutters">
     <?php
     foreach ( $tipologie_notizie as $id_tipologia_notizia ) {
+        if($ct >= $column)
+            break;
 
         $tipologia_notizia = get_term_by("id", $id_tipologia_notizia, "tipologia-articolo");
-    
         if($tipologia_notizia) {
             // se è selezionata solo una tipologia, pesco 2 elementi
             $ppp=1;
-            if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
+            if((count($tipologie_notizie) == 1) && ($home_show_events == "false")){
                 $ppp=2;
+                echo '<div class="row variable-gutters">';
+            }
             $args = array('post_type' => 'post',
                     'posts_per_page' => $ppp,
                     'tax_query' => array(
@@ -34,23 +35,8 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
                             'field' => 'term_id',
                             'terms' => $tipologia_notizia->term_id,
                         ),
-                	),
-            );
-        
-        	if($giorni_per_filtro != "" || $giorni_per_filtro > 0) {
-            	$filter = array(
-                		'date_query' => array(
-            				array(
-								'after' => '-'. $giorni_per_filtro . ' day',
-                				'inclusive' => true,
-            				),
-            			),
-        		);
-            
-				$args = array_merge($args,$filter);
-            	
-            }
-        
+                    ),
+                );
             $posts = get_posts($args);
 
             $lg = 4;
@@ -64,8 +50,6 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
                 </div><!-- /title-section -->
 
                 <?php
-                if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
-                    echo '<div class="row variable-gutters">';
                 foreach ($posts as $post) {
                     if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
                         echo '<div class="col-lg-6 mb-2">';
@@ -94,7 +78,7 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
 
         <!-- <div class="title-section <?php if($home_show_events == "true_event") echo 'pb-4'; ?>"> -->
         <div class="title-section pb-4">
-            <h2><?php _e("Eventi", "design_scuole_italia"); ?></h2>
+            <h2><?php _e("Prossimi Eventi", "design_scuole_italia"); ?></h2>
         </div><!-- /title-section -->
 
         <?php
@@ -126,7 +110,7 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
 
     ?>
     <div class="py-4">
-        <a class="text-underline" href="<?php echo get_post_type_archive_link("evento"); ?>"><strong><?php _e("Vedi tutti", "design_scuole_italia"); ?></strong></a>
+        <a class="text-underline" href="<?php echo get_post_type_archive_link("evento"); ?>?archive=true"><strong><?php _e("Consulta l'archivio", "design_scuole_italia"); ?></strong></a>
     </div>
     </div><!-- /col-lg-4 -->
     <?php


### PR DESCRIPTION
Modificato il box "eventi" quando la selezione automatica delle notizie è attiva ed è abilitata la visualizzazione mostra prossimo evento in home page.  Al posto del titolo che prima era solo "Eventi", adesso si legge "Prossimi Eventi". Inoltre, il link nel box eventi "vedi tutti" è stato rinominato in "Consulta l'archivio" e porta alla pagina  /evento/?archive=true (prima era solo /evento/ risultando spesso vuota). Con queste correzioni, ci sembra che la visualizzazione in home e la navigazione tra eventi futuri e passati sia più intuitiva e coerente.

<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->