### PR TITLE
Update utils.php aggiornamento anno scolastico sezione offerta formativa

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -798,8 +798,8 @@ function dsi_is_scuola($post){
  */
 function dsi_get_current_anno_scolastico($year = true){
     $today_month = date("n");
-    if($today_month < 8){
-        if($year) return date("Y")-1; else return dsi_convert_anno_scuola(date("Y")-1);
+    if($today_month > 6){
+        if($year) return date("Y")-0; else return dsi_convert_anno_scuola(date("Y")-0);
     }else{
         if($year) return date("Y"); else return dsi_convert_anno_scuola(date("Y"));
     }

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -801,7 +801,7 @@ function dsi_get_current_anno_scolastico($year = true){
     if($today_month > 6){
         if($year) return date("Y")-0; else return dsi_convert_anno_scuola(date("Y")-0);
     }else{
-        if($year) return date("Y"); else return dsi_convert_anno_scuola(date("Y"));
+        if($year) return date("Y")-1; else return dsi_convert_anno_scuola(date("Y")-1);
     }
 
 }


### PR DESCRIPTION
Questo fix sistema un errore che al 1 agosto nascondeva l'anno scolastico nella sezione "offerta formativa" in home e da menu didattica. 



<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Ho impostato la fine dell'anno scolastico al 30 giugno. Al 1 Luglio compare il nuovo anno scolastico.
La soluzione porta anche tutti i "progetti delle classi" nello storico della funzione "progetti degli scorsi anni"

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

Ho modificato l'inizio del nuovo anno scolastico impostando il valore maggiore di 6. 
modificato due parametri per la corretta visualizzazione del corrente anno scolastico.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->