### PR TITLE
Immagine card correlati allineata a destra

### DIFF
--- a/template-parts/single/card-vertical-thumb.php
+++ b/template-parts/single/card-vertical-thumb.php
@@ -7,7 +7,7 @@ $image_url = get_the_post_thumbnail_url($post, "vertical-card");
 
 ?><div class="card card-bg card-vertical-thumb bg-white card-thumb-rounded">
 	<div class="card-body">
-		<div class="card-content">
+		<div class="card-content flex-grow-1">
 			<h3 class="h5"><a href="<?php echo get_permalink($post); ?>"><?php echo get_the_title($post); ?></a></h3>
 
 <?php


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->
Attualmente, nelle card degli elementi correlati con immagine di anteprima, se il titolo o la descrizione non sono sufficientemente lunghi l'immagine di anteprima non è allineata a destra.
Applicando la classe `flex-grow-1` al div con il testo, questo si allarga occupando lo spazio rimanente, spingendo quindi l'immagine verso destra.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->