### PR TITLE
fix: breadcrumbs for "percorsi di studio"

### DIFF
--- a/inc/breadcrumb.php
+++ b/inc/breadcrumb.php
@@ -384,7 +384,7 @@ class Breadcrumb_Trail {
 					}
 					else if (is_tax(array("percorsi-di-studio"))){
 						$this->items[] = "<a href='".home_url("servizi")."'>".__("Servizi", "design_scuole_italia")."</a>";
-						$this->items[] = "<a href='".home_url("indirizzo-di-studio")."'>".__("Indirizzi di studio", "design_scuole_italia")."</a>";
+						$this->items[] = "<a href='".home_url("indirizzo-di-studio")."'>".__("Percorsi di studio", "design_scuole_italia")."</a>";
 					}
                     $this->add_term_archive_items();
                 } else if ( is_author() ) {


### PR DESCRIPTION
Modificato nome del breadcrumb "Indirizzo di studio" con "Percorsi di studio". Così facendo si crea coerenza con la pagina tipologie "Percorsi di studio"  (/indirizzo-di-studio)

<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->