### PR TITLE
Update style.css per l'allineamento immagini come già in v. 1.0

### DIFF
--- a/style.css
+++ b/style.css
@@ -10,3 +10,48 @@ Text Domain: design_scuole_italia
 /** immagini e allineamenti wp **/
 /* =WordPress Core
 -------------------------------------------------------------- */
+.alignnone {
+    margin: 5px 20px 20px 0;
+}
+
+.aligncenter,
+div.aligncenter {
+    display: block;
+    margin: 5px auto 5px auto;
+    max-width:100%;
+    height:auto;
+}
+
+.alignright {
+    float:right;
+    margin: 5px 0 20px 20px;
+    max-width:100%;
+    height:auto;
+}
+
+.alignleft {
+    float: left;
+    margin: 5px 20px 20px 0;
+    max-width:100%;
+    height:auto;
+}
+
+a img.alignright {
+    float: right;
+    margin: 5px 0 20px 20px;
+}
+
+a img.alignnone {
+    margin: 5px 20px 20px 0;
+}
+
+a img.alignleft {
+    float: left;
+    margin: 5px 20px 20px 0;
+}
+
+a img.aligncenter {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}


### PR DESCRIPTION
Nella migrazione dalla versione 1.0 alla versione 2.4 del tema, l'allineamento delle immagini viene perso in diverse pagine, a causa della mancanza delle relative classi css originariamente presenti nel file style.css, che si chiede di ripristinare.