### PR TITLE
Update circolare.php

### DIFF
--- a/inc/admin/circolare.php
+++ b/inc/admin/circolare.php
@@ -500,7 +500,9 @@ function dsi_circolare_modify_list_row_actions( $actions, $post ) {
         // Maybe put in some extra arguments based on the post status.
         $pdf_link = add_query_arg( array( 'pdf' => 'true' ), $url );
 
+        if (circolare_access($post->ID) != 'false') {
         $new_actions['pdf'] = sprintf( '<a href="%1$s"><b>%2$s</b></a>', esc_url( $pdf_link ), esc_html( __( 'PDF', 'design_scuole_italia' ) ) );
+		}
 
         if($notificato) {
             $csv_link = add_query_arg( array( 'csv' => 'true' ), $url );
@@ -513,9 +515,9 @@ function dsi_circolare_modify_list_row_actions( $actions, $post ) {
 
 // aggiungo bottone generazione pdf
 add_action( 'post_submitbox_misc_actions', function( $post ){
-    // check something using the $post object
-    if (( get_post_status( $post->ID ) === 'publish' ) && ( get_post_type($post->ID) == "circolare")){
-        echo '<div class="misc-pub-section"><a href="'. add_query_arg( array( 'pdf' => 'true' ), get_permalink($post->ID)).'" class="button" >Genera PDF</a></div>';
+    // check something using the $post object 
+    if (( get_post_status( $post->ID ) === 'publish' ) && ( get_post_type($post->ID) == "circolare") && (circolare_access($post->ID) != 'false') ){
+        echo '<div class="misc-pub-section"><a href="'. add_query_arg( array( 'pdf' => 'true' ), get_permalink($post->ID)).'" class="button" >Genera il PDF</a></div>';
     }
 });
 


### PR DESCRIPTION
Aggiunta nel backend la funzionalità di generazione del PDF delle circolari solo per gli utenti che hanno accesso alla circolare stessa. Il pulsante GENERA PDF e l'analoga opzione PDF nel quick ora è correttamente nascosta agli utenti che non devono accedere la circolare nel front-end.

## Descrizione

Fixes #487

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->