### PR TITLE
Campo e protezione URL media dall'accesso esterno

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -370,3 +370,76 @@ if ( $is_pubblica == "true" || ($is_pubblica == "false" && is_user_logged_in() &
 }
 return $accesso_circolare;
 }
+
+
+// Add custom checkbox attachment field
+function add_custom_protect_from_public_access_to_attachment_fields_to_edit( $form_fields, $post ) {
+    $protect_from_public_access = (bool) get_post_meta($post->ID, 'protect_from_public_access', true);
+	$ext = dsi_get_option("protect_from_public_access_extensions", "setup");
+	
+    $form_fields['protect_from_public_access'] = array(
+        'label' => 'Proteggi dall\'accesso esterno',
+        'input' => 'html',
+        'html' => '<input type="checkbox" ' . ($ext == "" ? 'disabled' : '') . ' id="attachments-'.$post->ID.'-protect_from_public_access" name="attachments['.$post->ID.'][protect_from_public_access]" value="1"'.($protect_from_public_access ? ' checked="checked"' : '').' /> ',
+        'value' => $protect_from_public_access,
+        'helps' => $ext == "" ? '<strong>Non &egrave; possibile proteggere il percorso del file dall\'accesso esterno. </strong> Vai in <a href="admin.php?page=setup">Configurazioni</a> e inserisci una o pi&ugrave; estensioni in base ai documenti riservati presenti nei media. Potrai selezionare l\'opzione e rendere accessibile l\'URL solo da utenti registrati' : 'Se l\'estensione del file &egrave; '. $ext .' (estensioni configurabili in <a href="admin.php?page=setup">Configurazioni</a>) e l\'opzione viene selezionata, il percorso del file sar&agrave; accessibile solo da utenti registrati.'
+    );
+	return $form_fields;
+}
+add_filter('attachment_fields_to_edit', 'add_custom_protect_from_public_access_to_attachment_fields_to_edit', null, 2); 
+
+// Save custom checkbox attachment field
+function save_protect_from_public_access_attachment_field($post, $attachment) { 
+    $db_protect_from_public_access = (bool) get_post_meta($post['ID'], 'protect_from_public_access', true);
+
+    if( isset($attachment['protect_from_public_access']) ){  
+        update_post_meta($post['ID'], 'protect_from_public_access', sanitize_text_field( $attachment['protect_from_public_access'] ) );  
+    }else{
+		delete_post_meta($post['ID'], 'protect_from_public_access' );
+    }
+    return $post;
+}
+add_filter('attachment_fields_to_save', 'save_protect_from_public_access_attachment_field', null, 2);
+
+function reserved_file_check(){
+	if($_GET && isset($_GET['action']) && $_GET['action'] == "reservedfilecheck"){
+		$baseurl = wp_get_upload_dir()['baseurl'];
+		$basedir = wp_get_upload_dir()['basedir'];
+		$filename = $baseurl . '/' . $_GET['file'];
+		$filepath = $basedir . '/' . $_GET['file'];
+
+		$fileid = attachment_url_to_postid( $filename );
+
+		if($fileid != 0) {
+			$filedata = get_post($fileid);
+
+			$protect_from_public_access = (bool) get_post_meta($filedata->ID, 'protect_from_public_access', true);
+
+			if($protect_from_public_access && !is_user_logged_in()) 
+				die();
+		}
+
+		if(file_exists($filepath)) {			
+			//Define header information
+			header('Content-Description: File Transfer');
+			header('Content-Type: application/octet-stream');
+			header("Cache-Control: no-cache, must-revalidate");
+			header("Expires: 0");
+			header('Content-Disposition: attachment; filename="'.basename($filepath).'"');
+			header('Content-Length: ' . filesize($filepath));
+			header('Pragma: public');
+
+			ob_clean();
+
+			//Clear system output buffer
+			flush();
+
+			//Read the size of the file
+			readfile($filepath);
+
+			//Terminate from the script
+			die();
+		}
+	}
+}
+add_action( 'init', 'reserved_file_check', 10, 2);

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1481,6 +1481,14 @@ function dsi_register_main_options_metabox() {
 		'type' => 'text'
     ) );
 
+    
+	$setup_options->add_field( array(
+		'id' => $prefix . 'protect_from_public_access_extensions',
+		'name' => 'Estensioni protette dall\'accesso esterno',
+		'desc' => __( 'Inserisci le estensioni di file (.ext) separate da una virgola da controllare per evitare accesso ad informazioni riservate. Per i file con tali estensioni sar&agrave; possibile configurare nei media l\'opzione per consentire l\'accesso solo da utenti registrati', 'design_scuole_italia' ),
+		'type' => 'text'
+    ) );
+
     $setup_options->add_field( array(
         'id' => $prefix . 'mail_circolari',
         'name'        => __( 'Configurazione email Circolari', 'design_scuole_italia' ),
@@ -1641,3 +1649,22 @@ function dsi_check_cron_options() {
         update_option('home_messages', $to_update, true);
     }
 }
+
+
+function dsi_check_media_htaccess(string $object_id, array $updated, CMB2 $cmb) {
+
+    $data = $cmb->data_to_save['protect_from_public_access_extensions'];
+    $data = str_replace(",", "|", $data);
+
+    $basedir = wp_get_upload_dir()['basedir'];
+
+    unlink($basedir . '\.htaccess');
+
+    if($data != "") {
+        $htaccesscontent = "RewriteRule \d{4}/(.*)[". $data . "]$ ". site_url( '', 'relative') ."/?action=reservedfilecheck&file=$0";
+        $htaccessfile = fopen($basedir . '\.htaccess', "w") or die("Unable to open file!");
+        fwrite($htaccessfile, $htaccesscontent);
+        fclose($htaccessfile);
+    }
+}
+add_action( 'cmb2_save_options-page_fields_dsi_setup_menu', 'dsi_check_media_htaccess', 10, 3 );


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

- Campo in configurazione per estensioni per le quali attivare protezione;
- htaccess per rendirizzare accesso a controllo;
- opzione in media per segnare file privato;
- metodo per il controllo.

All'interno dell'issue viene spiegata in dettaglio la soluzione.

Fixes #489 
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->