### PR TITLE
Opzioni per circolari e numero post in home

### DIFF
--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -365,6 +365,41 @@ function dsi_register_main_options_metabox() {
         ),
     ));
 
+    $home_options->add_field(array(
+        'id' => $prefix . 'home_show_circolari',
+        'name' => __('Mostra le circolari in Home', 'design_scuole_italia'),
+        'desc' => __('Abilita il riquadro delle circolari in Home', 'design_scuole_italia'),
+        'type' => 'radio_inline',
+        'default' => 'true_circolare',
+        'options' => array(
+            'false' => __('No', 'design_scuole_italia'),
+            'true_circolare' => __('Si, mostra la circolare pi&ugrave; recente', 'design_scuole_italia'),
+        ),
+        'attributes' => array(
+            'data-conditional-id' => $prefix . 'home_is_selezione_automatica',
+            'data-conditional-value' => "true",
+        ),
+    ));
+    
+	$home_options->add_field( array(
+        'id' => $prefix . 'home_post_per_tipologia',
+        'name' => 'Articoli da mostrare per ogni tipologia in Home',
+        'desc' => __( 'Qualora ci sia solo una tipologia selezionata, il numero di articoli minimo verr&agrave; calcolato in base allo spazio a disposizione nella prima riga. Se non compilato, il valore predefinito &egrave; 1.', 'design_scuole_italia' ),
+        'type' => 'text_small',
+        'default' => '1',
+        'attributes' => array(
+            'type' => 'number',
+            'pattern' => '\d*',
+            'min' => 1,
+        ),
+    	'attributes' => array(
+            'data-conditional-id' => $prefix . 'home_is_selezione_automatica',
+            'data-conditional-value' => "true",
+        ),
+        'sanitization_cb' => 'dsi_sanitize_int',
+        'escape_cb'       => 'dsi_sanitize_int',
+    ) );
+
     $home_options->add_field( array(
         'id' => $prefix . 'home_istruzioni_banner',
         'name'        => __( 'Sezione Banner', 'design_scuole_italia' ),

--- a/template-parts/home/articoli-eventi.php
+++ b/template-parts/home/articoli-eventi.php
@@ -2,15 +2,25 @@
 
 // global $calendar_card;
 
+global $set_card_top_margin;
+
 $tipologie_notizie = dsi_get_option("tipologie_notizie", "notizie");
 $home_show_events = dsi_get_option("home_show_events", "homepage");
+$home_show_circolari = dsi_get_option("home_show_circolari", "homepage");
 $giorni_per_filtro = dsi_get_option("giorni_per_filtro", "homepage");
 $data_limite_filtro = strtotime("-". $giorni_per_filtro . " day");
+$post_per_tipologia = dsi_get_option("home_post_per_tipologia", "homepage");
 
 $ct=0;
+
 $column = 1;
 if($home_show_events == "false")
-    $column = 2;
+    $column=$column+1;
+if($home_show_circolari == "false")
+    $column=$column+1;
+
+if($post_per_tipologia == "") $post_per_tipologia = 1;
+
 if(is_array($tipologie_notizie) && count($tipologie_notizie)){
     ?>
     <section class="section bg-white py-2 py-lg-3 py-xl-5">
@@ -23,9 +33,11 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
     
         if($tipologia_notizia) {
             // se è selezionata solo una tipologia, pesco 2 elementi
-            $ppp=1;
-            if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
-                $ppp=2;
+            $ppp=$post_per_tipologia;
+			
+            if(count($tipologie_notizie) == 1 && $post_per_tipologia < $column)
+                $ppp=$column;
+			
             $args = array('post_type' => 'post',
                     'posts_per_page' => $ppp,
                     'tax_query' => array(
@@ -54,8 +66,9 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
             $posts = get_posts($args);
 
             $lg = 4;
-            if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
-                $lg = 8;
+            if((count($tipologie_notizie) == 1))
+                $lg = $column * 4;
+
             if (is_array($posts) && count($posts)) { 
             ?>
             <div class="col-lg-<?php echo $lg; ?>">
@@ -64,18 +77,24 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
                 </div><!-- /title-section -->
 
                 <?php
-                if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
+                if((count($tipologie_notizie) == 1) && ($column > 1))
                     echo '<div class="row variable-gutters">';
+
+                $set_card_top_margin = false;
+
                 foreach ($posts as $post) {
-                    if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
-                        echo '<div class="col-lg-6 mb-2">';
+                    if((count($tipologie_notizie) == 1) && ($column > 1))
+                        echo '<div class="col-lg-' . (12/$column) . ' mb-4">';
+
                     get_template_part("template-parts/single/card", "vertical-thumb");
 
-                    if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
+                    if((count($tipologie_notizie) == 1) && ($column > 1))
                          echo '</div>';
+
+                    $set_card_top_margin = true;
                 }
 
-                if((count($tipologie_notizie) == 1) && ($home_show_events == "false"))
+                if((count($tipologie_notizie) == 1) && ($column > 1))
                     echo '</div>';
                 ?>
                 <div class="py-4">
@@ -123,16 +142,15 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
             // $calendar_card = true;
             // get_template_part("template-parts/evento/full_calendar");
         }
-
-    ?>
-    <div class="py-4">
-        <a class="text-underline" href="<?php echo get_post_type_archive_link("evento"); ?>?archive=true"><strong><?php _e("Consulta l'archivio", "design_scuole_italia"); ?></strong></a>
-    </div>
-    </div><!-- /col-lg-4 -->
+        ?>
+        <div class="py-4">
+            <a class="text-underline" href="<?php echo get_post_type_archive_link("evento"); ?>?archive=true"><strong><?php _e("Consulta l'archivio", "design_scuole_italia"); ?></strong></a>
+        </div>
+        </div><!-- /col-lg-4 -->
     <?php
-}
-?>
+    }
 
+    if($home_show_circolari != "false") { ?>
         <div class="col-lg-4">
 
             <div class="title-section pb-4">
@@ -153,6 +171,9 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
             </div>
 
         </div>
+    <?php
+    }
+    ?>
 
         </div><!-- /row -->
     </div><!-- /container -->

--- a/template-parts/single/card-vertical-thumb.php
+++ b/template-parts/single/card-vertical-thumb.php
@@ -1,11 +1,13 @@
 <?php
-global $post, $autore;
+global $post, $autore, $set_card_top_margin;
 $autore = get_user_by("ID", $post->post_author);
 
 $image_id= get_post_thumbnail_id($post);
 $image_url = get_the_post_thumbnail_url($post, "vertical-card");
+$show_contatore_commenti = dsi_get_option("show_contatore_commenti", "setup");
 
-?><div class="card card-bg card-vertical-thumb bg-white card-thumb-rounded">
+
+?><div class="card card-bg card-vertical-thumb bg-white card-thumb-rounded <?php echo $set_card_top_margin ? "mt-2" : ""; ?>">
 	<div class="card-body">
 		<div class="card-content">
 			<h3 class="h5"><a href="<?php echo get_permalink($post); ?>"><?php echo get_the_title($post); ?></a></h3>
@@ -35,7 +37,7 @@ $image_url = get_the_post_thumbnail_url($post, "vertical-card");
 	<div class="card-comments-wrapper">
 		<?php get_template_part("template-parts/autore/card"); ?>
         <?php
-        if($post->post_type == "post") {
+        if($post->post_type == "post" && $show_contatore_commenti != "false") {
 	        ?>
             <div class="comments">
                 <p><?php echo $post->comment_count; ?></p>


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

- Opzione per decidere se mostrare la circolare più recente in home;
- Opzione per scegliere il numero di elementi per ogni tipologia in home (qualora ci sia solo una tipologia selezionata, il numero di articoli minimo viene calcolato in base allo spazio a disposizione nella prima riga. Se non compilato, il valore predefinito è 1);
- Applicata l'opzione per mostrare o nascondere i commenti anche in home (caricamento automatico)

Fixes #493 #466 #294 
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

![image](https://github.com/italia/design-scuole-wordpress-theme/assets/13221786/3f90ef83-babc-456d-8946-43fdd2d401f9)


## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->