### PR TITLE
Mostra/Nascondi le circolari in panoramica

### DIFF
--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -974,7 +974,18 @@ function dsi_register_main_options_metabox() {
 		)
 	);
 
-
+	$notizie_options->add_field(array(
+	        'id' => $prefix . 'notizie_show_circolari_panoramica',
+	        'name' => __('Mostra le circolari in Panoramica', 'design_scuole_italia'),
+	        'desc' => __('Abilita il carosello delle circolari in Panoramica', 'design_scuole_italia'),
+	        'type' => 'radio_inline',
+	        'default' => 'true_circolare',
+	        'options' => array(
+	            'false' => __('No', 'design_scuole_italia'),
+	            'true_circolare' => __('Si, mostra il carosello', 'design_scuole_italia'),
+	        )
+    	));
+	
 	/**
 	 * Registers Didattica option page.
 	 */

--- a/template-parts/home/notizie-circolari.php
+++ b/template-parts/home/notizie-circolari.php
@@ -1,12 +1,14 @@
 <?php
 global $post, $tipologia_notizia, $ct, $servizio;
-
+$notizie_show_circolari_panoramica = dsi_get_option("notizie_show_circolari_panoramica", "notizie");
 $container_class = "bg-white";
 if($ct%2)
 	$container_class = "bg-gray-light";
 
 ?>
 
+
+<?php if($notizie_show_circolari_panoramica != "false") { ?>
 <section class="section <?php echo $container_class; ?> py-5">
 	<div class="container">
 		<div class="title-section mb-5">
@@ -35,3 +37,4 @@ if($ct%2)
 		</div>
 	</div><!-- /container -->
 </section><!-- /section -->
+<?php } ?>


### PR DESCRIPTION
Analogamente a quanto già fatto in home page (dove è possibile nascondere la card delle circolari) inseriamo la possibilità di scegliere se mostrare o meno la sezione delle circolari anche in panoramica. 
In questo modo, nel caso le scuole non abbiano neanche una circolare pubblicata - si evita che nella pagina di panoramica compaia lo stesso il titoletto "Le circolari" senza alcun contenuto sotto.

## Descrizione

1. Inserita la opzione nel backend (configurazione > Novità) per scegliere se mostrare o meno la sezione delle circolari nella pagina di panoramica delle notizie
2. Modificato il relativo template nel frontend per valutare la nuova variabile e mostrare/nasconde  la sezione corrispondente.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->