### PR TITLE
Fix selezione più gruppi utente in modifica utente

### DIFF
--- a/inc/extend-tax-to-user.php
+++ b/inc/extend-tax-to-user.php
@@ -189,7 +189,7 @@ class dsi_UserTaxonomies {
             if(!current_user_can('edit_user', $user_id) && current_user_can($taxonomy->cap->assign_terms)) return false;
 
             // Save the data
-            $terms	= array_map(fn($term) => esc_html($term), $_POST[$key]);
+            $terms	= array_map(fn($term) => esc_html($term), $_POST[$key] ?? []);
             
             wp_set_object_terms($user_id, $terms, $key, true);
             clean_object_term_cache($user_id, $key);

--- a/inc/extend-tax-to-user.php
+++ b/inc/extend-tax-to-user.php
@@ -153,7 +153,7 @@ class dsi_UserTaxonomies {
                     <td>
                         <?php if(!empty($terms)):?>
                             <?php foreach($terms as $term):?>
-                                <input type="checkbox" name="<?php echo $key?>" id="<?php echo "{$key}-{$term->slug}"?>" value="<?php echo $term->slug?>" <?php checked(true, is_object_in_term($user->ID, $key, $term))?> />
+                                <input type="checkbox" name="<?php echo $key?>[]" id="<?php echo "{$key}-{$term->slug}"?>" value="<?php echo $term->slug?>" <?php checked(true, is_object_in_term($user->ID, $key, $term))?> />
                                 <label for="<?php echo "{$key}-{$term->slug}"?>"><?php echo $term->name?></label><br />
                             <?php endforeach; // Terms?>
                         <?php else:?>
@@ -189,8 +189,9 @@ class dsi_UserTaxonomies {
             if(!current_user_can('edit_user', $user_id) && current_user_can($taxonomy->cap->assign_terms)) return false;
 
             // Save the data
-            $term	= esc_attr($_POST[$key]);
-            wp_set_object_terms($user_id, array($term), $key, true);
+            $terms	= array_map(fn($term) => esc_html($term), $_POST[$key]);
+            
+            wp_set_object_terms($user_id, $terms, $key, true);
             clean_object_term_cache($user_id, $key);
         }
     }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Nella pagina di modifica di un utente (in Utenti/Persone), selezionando più gruppi utente nelle checkbox in fondo alla pagina, ne viene salvato solo uno. È stato corretto questo comportamento.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->