### PR TITLE
Fix/eventi multi giorno in home e archivio

### DIFF
--- a/inc/actions.php
+++ b/inc/actions.php
@@ -151,29 +151,44 @@ function dsi_eventi_filters( $query ) {
             $query->set('meta_key', '_dsi_evento_timestamp_inizio' );
             $query->set('orderby', array('meta_value' => 'DESC', 'date' => 'DESC'));
             $query->set( 'meta_query', array(
+                'relation' => 'AND',
                 array(
-                    'key' => '_dsi_evento_timestamp_inizio'
+                    'key' => '_dsi_evento_timestamp_inizio',
+                    'value' => current_datetime()->modify('today')->getTimestamp(),
+                    'compare' => '<',
+                    'type' => 'numeric'
                 ),
                 array(
-                    'key' => '_dsi_evento_timestamp_fine',
-                    'value' => time(),
-                    'compare' => '<=',
-                    'type' => 'numeric'
+                    'relation' => 'OR',
+                    array(
+                        'key' => '_dsi_evento_timestamp_fine',
+                        'value' => current_datetime()->modify('today')->getTimestamp(),
+                        'compare' => '<',
+                        'type' => 'numeric'
+                    ),
+                    array(
+                        'key' => '_dsi_evento_timestamp_fine',
+                        'compare' => 'NOT EXISTS',
+                    ),
                 )
             ));
         }else{
             $query->set('meta_key', '_dsi_evento_timestamp_inizio' );
             $query->set('orderby', array('meta_value' => 'ASC', 'date' => 'ASC'));
             $query->set( 'meta_query', array(
-                array(
-                    'key' => '_dsi_evento_timestamp_inizio'
-                ),
+                'relation' => 'OR',
                 array(
                     'key' => '_dsi_evento_timestamp_fine',
-                    'value' => time(),
+                    'value' => current_datetime()->modify('today')->getTimestamp(),
                     'compare' => '>=',
                     'type' => 'numeric'
-                )
+                ),
+                array(
+                    'key' => '_dsi_evento_timestamp_inizio',
+                    'value' => current_datetime()->modify('today')->getTimestamp(),
+                    'compare' => '>=',
+                    'type' => 'numeric'
+                ),
             ));
 
         }

--- a/template-parts/home/articoli-eventi.php
+++ b/template-parts/home/articoli-eventi.php
@@ -118,20 +118,25 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
 
         <?php
         if ($home_show_events == "true_event") {
-            $args = array('post_type' => 'evento',
+            $args = array(
+                'post_type' => 'evento',
                 'posts_per_page' => 1,
                 'meta_key' => '_dsi_evento_timestamp_inizio',
-                'orderby'   =>  array('meta_value' => 'ASC', 'date' => 'ASC'),
+                'orderby' => 'meta_value',
+                'order' => 'ASC',
+                'meta_key' => '_dsi_evento_timestamp_inizio',
                 'meta_query' => array(
+                    'relation' => 'OR',
                     array(
-                        'key' => '_dsi_evento_timestamp_inizio'
+                        'key' => '_dsi_evento_timestamp_fine',
+                        'value' => current_datetime()->modify('-1 day')->getTimestamp(),
+                        'compare' => '>='
                     ),
                     array(
                         'key' => '_dsi_evento_timestamp_inizio',
-                        'value' => time(),
-                        'compare' => '>=',
-                        'type' => 'numeric'
-                    )
+                        'value' => current_datetime()->modify('-1 day')->getTimestamp(),
+                        'compare' => '>='
+                    ),
                 )
             );
             $posts = get_posts($args);

--- a/template-parts/home/articoli-eventi.php
+++ b/template-parts/home/articoli-eventi.php
@@ -124,7 +124,6 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
                 'meta_key' => '_dsi_evento_timestamp_inizio',
                 'orderby' => 'meta_value',
                 'order' => 'ASC',
-                'meta_key' => '_dsi_evento_timestamp_inizio',
                 'meta_query' => array(
                     'relation' => 'OR',
                     array(

--- a/template-parts/home/articoli-eventi.php
+++ b/template-parts/home/articoli-eventi.php
@@ -130,12 +130,14 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
                     array(
                         'key' => '_dsi_evento_timestamp_fine',
                         'value' => current_datetime()->modify('today')->getTimestamp(),
-                        'compare' => '>='
+                        'compare' => '>=',
+                        'type' => 'numeric'
                     ),
                     array(
                         'key' => '_dsi_evento_timestamp_inizio',
                         'value' => current_datetime()->modify('today')->getTimestamp(),
-                        'compare' => '>='
+                        'compare' => '>=',
+                        'type' => 'numeric'
                     ),
                 )
             );

--- a/template-parts/home/articoli-eventi.php
+++ b/template-parts/home/articoli-eventi.php
@@ -129,12 +129,12 @@ if(is_array($tipologie_notizie) && count($tipologie_notizie)){
                     'relation' => 'OR',
                     array(
                         'key' => '_dsi_evento_timestamp_fine',
-                        'value' => current_datetime()->modify('-1 day')->getTimestamp(),
+                        'value' => current_datetime()->modify('today')->getTimestamp(),
                         'compare' => '>='
                     ),
                     array(
                         'key' => '_dsi_evento_timestamp_inizio',
-                        'value' => current_datetime()->modify('-1 day')->getTimestamp(),
+                        'value' => current_datetime()->modify('today')->getTimestamp(),
                         'compare' => '>='
                     ),
                 )


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Attualmente la query degli eventi in home non tiene conto della data di fine degli eventi, quindi se è presente un evento iniziato in un giorno passato ma che finisce in un giorno futuro questo sparisce dalla home.
Nell'archivio, invece, un evento che finisce nel giorno attuale viene messo negli eventi passati.
Le modifiche effettuate dovrebbero correggere questo comportamento, e mostrare gli eventi fino alla conclusione del giorno in cui finiscono (sia in home sia in archivio).

Le nuove query inoltre tengono conto del caso in cui non sia presente una data di fine, assumendo che l'evento duri tutto il giorno della data di inizio.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->