### PR TITLE
Persone ruoli

### DIFF
--- a/page-templates/persone.php
+++ b/page-templates/persone.php
@@ -9,114 +9,75 @@ global $post;
 get_header();
 
 ?>
-    <main id="main-container" class="main-container bluelectric">
-        <?php get_template_part("template-parts/common/breadcrumb"); ?>
-        <?php
-        while ( have_posts() ) :
-            the_post();
-			get_template_part("template-parts/hero/persone");
+<main id="main-container" class="main-container bluelectric">
+	
+	<?php get_template_part("template-parts/common/breadcrumb"); ?>
+	
+	<?php get_template_part("template-parts/hero/persone"); ?>
+	
+	<section class="section <?php echo $classcolor; ?> py-5">
+		<div class="container">
+			<div class="title-section mb-5">
+				<h2 class="h4">
+				<?php $args = array('meta_key' => '_dsi_persona_ruolo_scuola','meta_value'	=> 'dirigente');
+				$users = get_users($args);$number_of_users = count($users); if ($number_of_users > 0) {echo 'Dirigente scolastico';}?>
+				</h2>
+			</div>	
+		<div class="row variable-gutters">	
+		<?php  
+		$args = array('meta_key' => '_dsi_persona_ruolo_scuola',  'meta_value'	=> 'dirigente');
+		$users = get_users($args);
+			foreach($users as $user){
+			$autore = get_user_by("ID", $user->data->ID);
+			get_template_part("template-parts/autore/card-persona");
+			}
+		?>
+		</div>		
+	</section>					
+				
+	<section class="section <?php echo $classcolor; ?> py-5">
+		<div class="container">
+			<div class="title-section mb-5">
+				<h2 class="h4">
+				<?php $args = array('meta_key' => '_dsi_persona_ruolo_scuola','meta_value'	=> 'docente');
+				$users = get_users($args);$number_of_users = count($users); if ($number_of_users > 0) {echo 'Personale docente';}?>
+				</h2>
+			</div>	
+		<div class="row variable-gutters">	
+		<?php  
+		$args = array('meta_key' => '_dsi_persona_ruolo_scuola',  'meta_value'	=> 'docente');
+		$users = get_users($args);
+			foreach($users as $user){
+			$autore = get_user_by("ID", $user->data->ID);
+			get_template_part("template-parts/autore/card-persona");
+			}
+		?>
+		</div>		
+	</section>	
 
-			// recupero la lista delle strutture
-            $i=0;
-            $strutture_persone = dsi_get_option("strutture_persone", "persone");
-            if($strutture_persone) {
-                foreach ($strutture_persone as $idstruttura) {
-                    $i++;
-                    $struttura = get_post($idstruttura);
 
-                    $classcolor = "bg-white";
-                    if ($i % 2)
-                        $classcolor = "bg-gray-light";
+	<section class="section <?php echo $classcolor; ?> py-5">
+		<div class="container">
+			<div class="title-section mb-5">
+				<h2 class="h4">
+				<?php $args = array('meta_key' => '_dsi_persona_ruolo_scuola','meta_value'	=> 'personaleata');
+				$users = get_users($args);$number_of_users = count($users); if ($number_of_users > 0) {echo 'Personale non docente';}?>
+				</h2>
+			</div>	
+		<div class="row variable-gutters">	
+		<?php  
+		$args = array('meta_key' => '_dsi_persona_ruolo_scuola',  'meta_value'	=> 'personaleata');
+		$users = get_users($args);
+			foreach($users as $user){
+			$autore = get_user_by("ID", $user->data->ID);
+			get_template_part("template-parts/autore/card-persona");
+			}
+		?>
+		</div>		
+	</section>	
+	
 
-                    $responsabile = dsi_get_meta("responsabile", "_dsi_struttura_", $struttura->ID);
-                    $persone = dsi_get_meta("persone", "_dsi_struttura_", $struttura->ID);
-                    $altri_componenti = dsi_get_meta("altri_componenti", "_dsi_struttura_", $struttura->ID);
-
-                    ?>
-                    <section class="section <?php echo $classcolor; ?> py-5">
-                        <div class="container">
-                            <div class="title-section text-center mb-5">
-                                <h2 class="h4"><a
-                                            href="<?php echo get_permalink($struttura); ?>"><?php echo $struttura->post_title; ?></a>
-                                </h2>
-                            </div><!-- /title-large -->
-                            <?php if (is_array($responsabile) && count($responsabile) > 0) { ?>
-                                <div class="row variable-gutters mb-4">
-                                    <div class="col-lg-3">
-                                        <h3 class="text-lg-right mb-3"><?php _e("Responsabile", "design_scuole_italia"); ?></h3>
-                                    </div><!-- /col-lg-3 -->
-                                    <div class="col-lg-9">
-                                        <div class="row variable-gutters">
-                                            <?php
-                                            foreach ($responsabile as $idutente) {
-                                                $autore = get_user_by("ID", $idutente);
-                                                ?>
-                                                <div class="col-lg-4">
-                                                    <div class="card card-bg bg-color bg-dark card-avatar rounded mb-3">
-                                                        <div class="card-body">
-                                                            <?php get_template_part("template-parts/autore/card"); ?>
-                                                        </div><!-- /card-body -->
-                                                    </div><!-- /card card-bg card-avatar rounded -->
-                                                </div><!-- /col-lg-4 -->
-                                                <?php
-                                            }
-                                            ?>
-                                        </div><!-- /row -->
-                                    </div><!-- /col-lg-9 -->
-                                </div><!-- /row -->
-                            <?php } ?>
-
-                            <?php if (is_array($persone) && count($persone) > 0) { ?>
-                                <div class="row variable-gutters mb-4">
-                                    <div class="col-lg-3">
-                                        <h4 class="text-lg-right mb-3"><?php _e("Persone", "design_scuole_italia"); ?></h4>
-                                    </div><!-- /col-lg-3 -->
-                                    <div class="col-lg-9">
-                                        <div class="row variable-gutters">
-                                            <?php
-                                            foreach ($persone as $idutente) {
-                                                $autore = get_user_by("ID", $idutente);
-                                                ?>
-                                                <div class="col-lg-4">
-                                                    <div class="card card-bg bg-white card-avatar rounded mb-3">
-                                                        <div class="card-body">
-                                                            <?php get_template_part("template-parts/autore/card"); ?>
-                                                        </div><!-- /card-body -->
-                                                    </div><!-- /card card-bg card-avatar rounded -->
-                                                </div><!-- /col-lg-4 -->
-                                                <?php
-                                            }
-                                            ?>
-                                        </div><!-- /row -->
-                                    </div><!-- /col-lg-9 -->
-                                </div><!-- /row -->
-                            <?php } ?>
-
-                            <?php if ($altri_componenti != "") { ?>
-                                <div class="row variable-gutters mb-4">
-                                    <div class="col-lg-3">
-                                        <h3 class="h4 text-lg-right mb-3"><?php _e("Componenti esterni", "design_scuole_italia"); ?></h3>
-                                    </div><!-- /col-lg-3 -->
-                                    <div class="col-lg-9">
-                                        <div class="row variable-gutters">
-                                            <span class="h5 text-lg-right mb-3 pt-1 pl-4">
-                                                <?php echo $altri_componenti; ?>
-                                            </span>
-                                        </div><!-- /row -->
-                                    </div><!-- /col-lg-9 -->
-                                </div><!-- /row -->
-                            <?php } ?>
-
-                        </div><!-- /container -->
-                    </section><!-- /section -->
-                    <?php
-
-                }
-            }
-
-        endwhile; // End of the loop.
-        ?>
-    </main>
+</main>
 
 <?php
 get_footer();

--- a/template-parts/autore/card-persona.php
+++ b/template-parts/autore/card-persona.php
@@ -1,0 +1,26 @@
+<?php
+global $autore;
+$image_id = null;
+$foto_url = get_the_author_meta('_dsi_persona_foto', $autore->ID);
+if($foto_url)
+	$image_id = attachment_url_to_postid($foto_url);
+$image_url = dsi_get_user_avatar($autore);
+?>
+<div class="col-lg-4">
+	<div class="card card-bg bg-white card-avatar rounded mb-3 card-persona">
+		<div class="card-body">                     
+			<div class="card-avatar-img">
+				<?php dsi_get_img_from_id_url( $image_id, $image_url ); ?>
+			</div><!-- /card-avatar-img -->
+			<div class="card-avatar-content">
+				<p class="font-weight-normal">
+					<a href="<?php echo get_author_posts_url( $autore->ID); ?>" aria-label="vai alla pagina di <?php echo dsi_get_display_name( $autore->ID ); ?>">
+						<strong class="text-underline"><u><?php echo dsi_get_display_name( $autore->ID ); ?></u></strong>
+					</a>
+				</p>
+				<small><?php echo dsi_get_user_role($autore); ?></small>
+			</div><!-- /card-avatar-content -->
+		</div>
+	</div>
+</div>
+


### PR DESCRIPTION
Modificata la pagina delle persone per renderla coerente con il modello

## Descrizione
Nella pagina delle persone, come previsto  previsti dall'[architettura dell'informazione](https://designers.italia.it/files/resources/modelli/scuole/adotta-il-modello-di-sito-scolastico/definisci-architettura-e-contenuti/Alberatura-ModelloScuole-DesignersItalia.pdf), dovrebbero comparire le schede degli utenti che abbiano tre ruoli precisi: 1) dirigente scolastico, 2) personale docente e 3) personale non docente. 
Sebbene nel backend sia possibile anzi obbligatorio attribuire agli utenti tali ruoli nell'organizzazione, queste informazioni non erano poi disponibili nella pagina delle Persone come previsto. 
Le modifiche nel codice consentono di visualizzare, per ciascuna sezione/ruolo, la lista degli utenti associati a quello specifico ruolo (se non ne esiste almeno uno la sezione non viene visualizzata) rendendo la pagina conforme ai requisiti.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->