### PR TITLE
Icone servizi in home e altezza card uguale

### DIFF
--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -479,6 +479,18 @@ function dsi_register_main_options_metabox() {
     ));
 
     $home_options->add_field(array(
+        'id' => $prefix . 'home_icone_servizi',
+        'name' => __('Icona servizi', 'design_scuole_italia'),
+        'desc' => __('Seleziona per mostrare l\'immagine del servizio accanto al suo nome', 'design_scuole_italia'),
+        'type' => 'radio_inline',
+        'default' => 'false',
+        'options' => array(
+            'true' => __('Si', 'design_scuole_italia'),
+            'false' => __('No', 'design_scuole_italia'),
+        ),
+    ));
+
+    $home_options->add_field(array(
             'name' => __('Selezione articoli ', 'design_scuole_italia'),
             'desc' => __('Seleziona gli articoli da mostrare in Home Page. NB: Selezionane 3 o multipli di 3 per evitare buchi nell\'impaginazione.  ', 'design_scuole_italia'),
             'id' => $prefix . 'home_servizi_manuali',

--- a/template-parts/home/list-servizi.php
+++ b/template-parts/home/list-servizi.php
@@ -7,6 +7,9 @@ $home_servizi_manuali = dsi_get_option("home_servizi_manuali", "homepage");
     <div class="row variable-gutters mb-4">
         <?php
         $home_is_selezione_automatica_servizi = dsi_get_option("home_is_selezione_automatica_servizi", "homepage");
+        $home_mostra_icone = dsi_get_option("home_icone_servizi", "homepage") == "true";
+        $home_mostra_icone = $home_mostra_icone ? "icon" : "noicon";
+        
         if($home_is_selezione_automatica_servizi != "false"){
             $args = array('post_type' => 'servizio',
                 'posts_per_page' => 6,
@@ -15,7 +18,7 @@ $home_servizi_manuali = dsi_get_option("home_servizi_manuali", "homepage");
             foreach ($servizi as $servizio) {
                 ?>
                 <div class="col-lg-4 mb-4">
-                    <?php get_template_part("template-parts/servizio/card", "noicon"); ?>
+                    <?php get_template_part("template-parts/servizio/card", $home_mostra_icone); ?>
                 </div><!-- /col-lg-4 -->
                 <?php
             }
@@ -25,7 +28,7 @@ $home_servizi_manuali = dsi_get_option("home_servizi_manuali", "homepage");
                  $servizio = get_post($idservizio);
                     ?>
                     <div class="col-lg-4 mb-4">
-                        <?php get_template_part("template-parts/servizio/card", "noicon"); ?>
+                        <?php get_template_part("template-parts/servizio/card", $home_mostra_icone); ?>
                     </div><!-- /col-lg-4 -->
                     <?php
 

--- a/template-parts/servizio/card-icon.php
+++ b/template-parts/servizio/card-icon.php
@@ -3,7 +3,7 @@ global $servizio;
 
 $image_id = get_post_thumbnail_id($servizio);
 if (has_post_thumbnail($servizio))
-    $image_url = get_the_post_thumbnail_url($servizio, "item-thumb");
+    $image_url = get_the_post_thumbnail_url($servizio, "thumbnail");
 
 
 if ($servizio->post_status == "publish") {

--- a/template-parts/servizio/card-icon.php
+++ b/template-parts/servizio/card-icon.php
@@ -2,9 +2,12 @@
 global $servizio;
 if($servizio->post_status == "publish") {
     ?>
-    <div class="card card-wrapper card-bg card-noicon rounded">
+    <div class="card card-wrapper card-bg card-icon rounded">
         <a href="<?php echo get_permalink($servizio); ?>">
             <div class="card-body">
+                <div class="avatar size-xl flex-shrink-0 mr-2">
+                    <img src="https://randomuser.me/api/portraits/men/33.jpg" alt="Carlo Poli">
+                </div>
                 <div class="card-icon-content" id="card-desc-<?php echo $servizio->ID; ?>">
                     <p><strong><?php echo $servizio->post_title; ?></strong></p>
                     <small><?php echo dsi_get_meta("sottotitolo", '_dsi_servizio_', $servizio->ID); ?></small>

--- a/template-parts/servizio/card-icon.php
+++ b/template-parts/servizio/card-icon.php
@@ -1,19 +1,31 @@
 <?php
 global $servizio;
-if($servizio->post_status == "publish") {
-    ?>
+
+$image_id = get_post_thumbnail_id($servizio);
+if (has_post_thumbnail($servizio))
+    $image_url = get_the_post_thumbnail_url($servizio, "item-thumb");
+
+
+if ($servizio->post_status == "publish") {
+?>
     <div class="card card-wrapper card-bg card-icon rounded">
         <a href="<?php echo get_permalink($servizio); ?>">
             <div class="card-body">
-                <div class="avatar size-xl flex-shrink-0 mr-2">
-                    <img src="https://randomuser.me/api/portraits/men/33.jpg" alt="Carlo Poli">
-                </div>
-                <div class="card-icon-content" id="card-desc-<?php echo $servizio->ID; ?>">
+                <div class="card-icon-content flex-grow-1" id="card-desc-<?php echo $servizio->ID; ?>">
                     <p><strong><?php echo $servizio->post_title; ?></strong></p>
                     <small><?php echo dsi_get_meta("sottotitolo", '_dsi_servizio_', $servizio->ID); ?></small>
                 </div><!-- /card-icon-content -->
+                <?php
+                if (isset($image_url)) {
+                ?>
+                    <div class="avatar size-xl flex-shrink-0 ml-3">
+                        <?php dsi_get_img_from_id_url( $image_id, $image_url );  ?>
+                    </div>
+                <?php
+                }
+                ?>
             </div><!-- /card-body -->
         </a>
     </div><!-- /card card-bg rounded -->
-    <?php
+<?php
 }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Aggiunta dell'opzione per mostrare l'icona dei servizi nelle loro card in home. Le card ora hanno tutte altezza uguale.
Qualora non attivata, la visualizzazione rimane quella senza icona.

![image](https://github.com/italia/design-scuole-wordpress-theme/assets/13221786/59b58d95-c6b5-4a20-970a-26b9fe2480e8)

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->