### PR TITLE
Possibilità di scegliere più categorie della trasparenza per un singolo documento

### DIFF
--- a/inc/admin/documento.php
+++ b/inc/admin/documento.php
@@ -562,7 +562,7 @@ function dsi_append_documenti_post_status_list(){
         echo '
       <script>
       jQuery(document).ready(function($){
-      	   if($("input:radio[name=_dsi_documento_is_amministrazione_trasparente]:checked").val() === true) {
+      	   if($("input:radio[name=_dsi_documento_is_amministrazione_trasparente]:checked").val() == "true") {
                 $( "#taxonomy-amministrazione-trasparente" ).parent().parent().show();
            } else {
     		    $( "#taxonomy-amministrazione-trasparente" ).parent().parent().hide();


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Il miglioramento prevede la possibilità di pubblicare il documento in più sezioni di amministrazione trasparente.

<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->