### PR TITLE
Update breadcrumb.php

### DIFF
--- a/inc/breadcrumb.php
+++ b/inc/breadcrumb.php
@@ -411,7 +411,7 @@ class Breadcrumb_Trail {
                     $this->add_term_archive_items();
                 } else if ( is_author() ) {
 					$this->items[] = "<a href='".home_url("la-scuola")."'>".__("Scuola", "design_scuole_italia")."</a>";
-					$this->items[] = "<a href='".home_url("la-scuola/persone")."'>".__("Le persone", "design_scuole_italia")."</a>";
+					$this->items[] = "<a href='".home_url("la-scuola/le-persone")."'>".__("Le persone", "design_scuole_italia")."</a>";
 					$this->add_user_archive_items();
 				} else if ( get_query_var( 'minute' ) && get_query_var( 'hour' ) ) {
 					$this->add_minute_hour_archive_items();


### PR DESCRIPTION

<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
L'ultimo fix#551 al breadcrumb "Home/Scuola/Le persone/author" ha generato un errore 404 sulla pagina foglia.
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
La correzione proposta coinvolge una modifica al codice, precisamente alla riga 414 del file inc/breadcrumb.php: Questa correzione sostituisce la parte finale dell'URL da "persone" a "le-persone".  L'obiettivo è risolvere il problema associato al breadcrumb, prevenendo così l'errore 404.
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->
#557
![le-persone](https://github.com/italia/design-scuole-wordpress-theme/assets/9642253/a6a9f7f6-b477-466c-8fea-3e644e3443a1)

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ X] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [X ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->