### PR TITLE
feat: aggiunta classe per mostrare la tipologia della circolare in un badge

### DIFF
--- a/template-parts/list/article-circolare.php
+++ b/template-parts/list/article-circolare.php
@@ -38,7 +38,7 @@ $accesso_circolare = circolare_access($post->ID);
 	<?php $post_tags = get_the_terms(get_the_ID(), 'tipologia-circolare'); 
 		if ($post_tags) {
 			foreach($post_tags as $tag) {
-			echo '<a href="'.get_tag_link($tag->term_id).'" aria-label="Tipologia: '.$tag->name.'">'. $tag->name .'</a><br>';
+			echo '<a href="'.get_tag_link($tag->term_id).'" class="badge badge-sm badge-pill badge-outline-greendark" aria-label="Tipologia: '.$tag->name.'">'. $tag->name .'</a> ';
 			}
 		}
 	?>


### PR DESCRIPTION
Aggiunta classe per mostrare in un badge la tipologia della circolare nelle cards
Questa PR completa la PR [537](la https://github.com/italia/design-scuole-wordpress-theme/pull/537) 



## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->