### PR TITLE
Data attributes al contenuto della pagina note legali

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -459,3 +459,15 @@ function reserved_file_check(){
 	}
 }
 add_action( 'init', 'reserved_file_check', 10, 2);
+
+// aggiungi data elements alla pagina note-legali
+function insert_data_attribute_note_legali( $content ) {
+	if (is_page( 'note-legali')) {
+		$search  = array('<h2>Licenza dei contenuti', '<p>In applicazione del principio');
+		$replace = array('<h2 data-element="legal-notes-section">Licenza dei contenuti', '<p data-element="legal-notes-body">In applicazione del principio');
+	return str_replace($search, $replace, $content);
+
+	}   
+	else return $content; 
+	}
+add_filter('the_content', 'insert_data_attribute_note_legali');


### PR DESCRIPTION
Per assicurare la conformità con la raccomandazione R.SC.2.2 - Licenza e attribuzione, nella pagina delle note legali deve essere presente un tag HTML con l’attributo data–element=”legal-notes-section” da inserire nell'header contenente il titolo della sezione e l'attributo data-element=”legal-notes-body” inserito nel paragrafo contenente il testo della sezione. 
Questa aggiunta al codice consente di inserirli automaticamente e superare i relativi controlli della app di validazione.

## Descrizione
La funzione individua la pagina con lo slug note-legali ed appende al titolo h2 "Licenza dei contenuti" il `data-element="legal-notes-section"` ed al paragrafo che inizia con il testo "In applicazione del principio" il `data-element="legal-notes-body"`.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->