### PR TITLE
Editor wysiwyg per campi indirizzo - procedure, orario, libri, casi particolari

### DIFF
--- a/inc/admin/indirizzo.php
+++ b/inc/admin/indirizzo.php
@@ -200,7 +200,12 @@ function dsi_add_indirizzo_metaboxes() {
         'id' => $prefix . 'procedura_esito',
         'name'        => __( 'Procedure collegate', 'design_scuole_italia' ),
         'desc' => __( 'Questo campo indica eventuali procedure collegate.' , 'design_scuole_italia' ),
-        'type' => 'textarea'
+        'type' => 'wysiwyg',
+        'options' => array(
+            'media_buttons' => false, // show insert/upload button(s)
+            'textarea_rows' => 4, // rows="..."
+            'teeny' => true, // output the minimal editor config used in Press This
+        ),
     ) );
 
     $cmb_undercontent->add_field( array(
@@ -316,8 +321,12 @@ function dsi_add_indirizzo_metaboxes() {
         'id' => $prefix . 'calendario_classi_descrizione',
         'name'        => __( 'L\'orario delle classi', 'design_scuole_italia' ),
         'desc' => __( 'Testo introduttivo' , 'design_scuole_italia' ),
-        'type' => 'textarea',
-
+        'type' => 'wysiwyg',
+        'options' => array(
+            'media_buttons' => false, // show insert/upload button(s)
+            'textarea_rows' => 4, // rows="..."
+            'teeny' => true, // output the minimal editor config used in Press This
+        ),
     ) );
     $cmb_undercontent->add_field( array(
         'id' => $prefix . 'calendario_classi_file',
@@ -337,7 +346,12 @@ function dsi_add_indirizzo_metaboxes() {
         'id' => $prefix . 'libri_testo_descrizione',
         'name'        => __( 'Libri di testo', 'design_scuole_italia' ),
         'desc' => __( 'Testo introduttivo' , 'design_scuole_italia' ),
-        'type' => 'textarea',
+        'type' => 'wysiwyg',
+        'options' => array(
+            'media_buttons' => false, // show insert/upload button(s)
+            'textarea_rows' => 4, // rows="..."
+            'teeny' => true, // output the minimal editor config used in Press This
+        ),
     ) );
     $cmb_undercontent->add_field( array(
         'id' => $prefix . 'libri_testo_file',
@@ -431,8 +445,12 @@ function dsi_add_indirizzo_metaboxes() {
         'id' => $prefix . 'casi_particolari',
         'name'        => __( 'Casi particolari', 'design_scuole_italia' ),
         'desc' => __( 'Inserire come testo libero, eventuali casi particolari riferiti all\'ottenimento del Servizio in questione.' , 'design_scuole_italia' ),
-        'type' => 'textarea',
-
+        'type' => 'wysiwyg',
+        'options' => array(
+            'media_buttons' => false, // show insert/upload button(s)
+            'textarea_rows' => 4, // rows="..."
+            'teeny' => true, // output the minimal editor config used in Press This
+        ),
     ) );
 
     $cmb_undercontent->add_field( array(


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Attivati gli editor wysiwyg per campi indirizzo - procedure, orario, libri, casi particolari. L'esigenza nasce dal prevedere, ad esempio, una lista puntata con vari orari.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->