### PR TITLE
Correzione bug visualizzazione indirizzi di studio con visualizzazione Indirizzi/Scuole

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -1143,3 +1143,42 @@ if(!function_exists("dsi_get_img_from_id_url")) {
         echo $img;
     }
 }
+
+if (!function_exists("dsi_is_object_in_term_or_term_ancestors")) {
+    /**
+     * Determines if the given object is associated with any of the given terms or with any of the terms' children.
+     * @param int $id ID of the object (post ID, link ID, …).
+     * @param string $taxonomy Single taxonomy name.
+     * @param int|string|array $terms Term ID, slug, or array of such to check against.
+     * @return bool|WP_Error WP_Error on input error.
+     */
+    function dsi_is_object_in_term_or_child_term(int $object_id, string $taxonomy, $terms = null)
+    {
+        $is_object_in_term = is_object_in_term($object_id, $taxonomy, $terms);
+
+        if(is_wp_error($is_object_in_term) || $is_object_in_term)
+            return $is_object_in_term;
+
+        $object_terms = wp_get_object_terms($object_id, $taxonomy);
+
+        if (empty($object_terms)) {
+            return false;
+        }
+
+        $terms = (array) $terms;
+
+        foreach ($object_terms as $object_term) {
+            foreach ($terms as $term) {
+                if (is_numeric($term))
+                    $term_id = (int) $term;
+                else
+                    $term_id = get_term_by('slug', $term, $taxonomy)->term_id;
+
+                if ($term_id && (term_is_ancestor_of($term_id, $object_term, $taxonomy)))
+                    return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/template-parts/home/didattica-cicli-indirizzi.php
+++ b/template-parts/home/didattica-cicli-indirizzi.php
@@ -27,13 +27,11 @@ if(is_array($indirizzi_didattica) && count($indirizzi_didattica)>0) {
                                 <?php
                             foreach ($indirizzi_didattica as $slugindirizzo){
                                 $indirizzo = get_term_by("slug", $slugindirizzo,"percorsi-di-studio");
-                                if($indirizzo && 'trash' !== get_post_status($idindirizzo)) {
                                 ?>
-                                        <li>
-                                            <a href="#tab-<?php echo $slugindirizzo; ?>"><?php echo $indirizzo->name; ?></a>
-                                        </li>
+                                <li>
+                                    <a href="#tab-<?php echo $slugindirizzo; ?>"><?php echo $indirizzo->name; ?></a>
+                                </li>
                                 <?php
-                                    }
                                 }
                                 ?>
                             </ul>
@@ -90,7 +88,7 @@ if(is_array($indirizzi_didattica) && count($indirizzi_didattica)>0) {
                                                             $count_indirizzi_in_percorso_selezionato = 0;
                                                             //echo "<div class='col-12'><small><strong>Percorsi di studio</strong></small></div>";
                                                             foreach ($indirizzi as $idindirizzo) {
-                                                                if (get_the_title($idindirizzo) != "" && is_object_in_term($idindirizzo, 'percorsi-di-studio', $slugindirizzo)) {
+                                                                if (get_the_title($idindirizzo) != "" && dsi_is_object_in_term_or_child_term($idindirizzo, 'percorsi-di-studio', $slugindirizzo)) {
                                                                     $count_indirizzi_in_percorso_selezionato++;
 
                                                         ?>
@@ -127,7 +125,7 @@ if(is_array($indirizzi_didattica) && count($indirizzi_didattica)>0) {
                                             }
                                         } else{
                                             echo '<div ><h5 class="text-white">';
-                                            _e("Nessun istituto associato a questa indirizzo di studi.", "design_scuole_italia");
+                                            _e("Nessun istituto associato a questo indirizzo di studi.", "design_scuole_italia");
                                             echo '</h5></div>';
                                         }
                                         ?>


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->
Esiste un problema per cui scegliendo la visualizzazione Indirizzi/Scuole, nelle impostazioni della didattica, nelle scuole secondarie non vengono visualizzati i relativi percorsi di studio (come invece avviene per le scuole primarie e dell'infanzia):
![Screenshot 2024-02-05 153549](https://github.com/italia/design-scuole-wordpress-theme/assets/13221786/d8996cf9-d627-4c9f-8bc1-b1f43613dd0f)

Con la modifica, i percorsi associati alle scuole secondarie vengono visualizzati:
![Screenshot 2024-02-05 153519](https://github.com/italia/design-scuole-wordpress-theme/assets/13221786/a2680bb0-892d-4967-959e-5f2d23af0ae5)

Il problema è dovuto al modo in cui viene gestita la tassonomia dei percorsi di studio: le scuole (intese come strutture organizzative) possono essere associate solo a percorsi di primo livello, mentre i percorsi di studio solo a percorsi _foglia_. Lo scenario che ha evidenziato il problema è questo: un percorso musicale è associato al termine "Indirizzo musicale", figlio di "Scuola secondaria di primo grado", mentre la struttura organizzativa che eroga l'indirizzo musicale è associata al termine "Scuola secondaria di primo grado". Nel codice PHP della pagina della didattica, sotto ad ogni scuola, vengono visualizzati i percorsi che condividono lo stesso indirizzo della scuola, ma l'indirizzo musicale non è considerato uguale a scuola secondaria, di conseguenza non viene visualizzato. Il problema è stato risolto utilizzando una nuova funzione che controlla se un post fa parte di un certo termine o dei figli di quel certo termine.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->