### PR TITLE
aggiunta opzione per collegare documenti alle strutture

### DIFF
--- a/inc/admin/struttura.php
+++ b/inc/admin/struttura.php
@@ -237,6 +237,39 @@ function dsi_add_struttura_metaboxes() {
 
 
     $cmb_undercontent->add_field( array(
+		'id' => $prefix . 'link_schede_documenti',
+		'name'    => __( 'Documenti', 'design_scuole_italia' ),
+		'desc' => __( 'Inserisci qui tutti i documenti che ritieni utili per attivare il servizio: moduli da compilare, riferimenti di legge e altre informazioni. Se devi caricare il documento <a href="post-new.php?post_type=documento">puoi creare una breve scheda di presentazione</a> (soluzione consigliata e più efficace per gli utenti del sito) oppure caricarlo direttamente nei campi che seguono. ' , 'design_scuole_italia' ),
+		'type'    => 'custom_attached_posts',
+		'column'  => true, // Output in the admin post-listing as a custom column. https://github.com/CMB2/CMB2/wiki/Field-Parameters#column
+		'options' => array(
+			'show_thumbnails' => false, // Show thumbnails on the left
+			'filter_boxes'    => true, // Show a text box for filtering the results
+			'query_args'      => array(
+				'posts_per_page' => 10,
+				'post_type'      => 'documento',
+			), // override the get_posts args
+		),
+	) );
+
+
+	$cmb_undercontent->add_field( array(
+		'id' => $prefix . 'file_documenti',
+		'name'    => __( 'Carica documenti', 'design_scuole_italia' ),
+		'desc' => __( 'Se l\'allegato non è descritto da una scheda documento, link all\'allegato (es. link a una locandina). ' , 'design_scuole_italia' ),
+		'type' => 'file_list',
+		// 'preview_size' => array( 100, 100 ), // Default: array( 50, 50 )
+		// 'query_args' => array( 'type' => 'image' ), // Only images attachment
+		// Optional, override default text strings
+		'text' => array(
+			'add_upload_files_text' => __('Aggiungi un nuovo Documento', 'design_scuole_italia' ), // default: "Add or Upload Files"
+			'remove_image_text' => __('Rimuovi Documento', 'design_scuole_italia' ), // default: "Remove Image"
+			'remove_text' => __('Rimuovi', 'design_scuole_italia' ), // default: "Remove"
+		),
+	) );
+
+
+    $cmb_undercontent->add_field( array(
             'name'       => __('Persone responsabili ', 'design_scuole_italia' ),
             'desc' => __( 'Link alla scheda responsabile della struttura. ', 'design_scuole_italia' ),
             'id' => $prefix . 'responsabile',

--- a/single-struttura.php
+++ b/single-struttura.php
@@ -31,6 +31,9 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
             $link_schede_servizi = dsi_get_meta("link_schede_servizi");
             $link_schede_progetti = dsi_get_meta("link_schede_progetti");
 
+            $link_schede_documenti = dsi_get_meta("link_schede_documenti");
+            $file_documenti = dsi_get_meta("file_documenti");        
+
             $responsabile = dsi_get_meta("responsabile")?dsi_get_meta("responsabile"):"";
             $persone = dsi_get_meta("persone");
             $altri_componenti = dsi_get_meta("altri_componenti");
@@ -141,6 +144,30 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                                                 <a class="list-item scroll-anchor-offset" href="#art-par-servizi" title="Vai al paragrafo <?php _e("Servizi", "design_scuole_italia"); ?>"><?php _e("Servizi", "design_scuole_italia"); ?></a>
                                             </li>
                                         <?php } ?>
+
+
+
+
+
+
+                                        <?php if((is_array($link_schede_documenti) && count($link_schede_documenti)>0) || (is_array($file_documenti) && count($file_documenti)>0)){ ?>
+                                            <li>
+                                                <a class="list-item scroll-anchor-offset" href="#art-par-documenti" title="<?php _e("Vai al paragrafo", "design_scuole_italia"); ?> <?php _e("Documenti", "design_scuole_italia"); ?>"><?php _e("Documenti", "design_scuole_italia"); ?></a>
+                                            </li>
+                                        <?php } ?>
+
+
+
+
+
+
+
+
+
+
+
+
+
                                         <?php  if((is_array($responsabile) && count($responsabile)>0) || (is_array($persone) && count($persone)>0) || $altri_componenti != "" ||  $telefono || $mail  || ( $post->post_parent == 0 && $children) || ($post->post_parent > 0)){  ?>
                                             <li>
                                                 <a class="list-item scroll-anchor-offset" href="#art-par-organizzazione" title="Vai al paragrafo <?php _e("Organizzazione e contatti", "design_scuole_italia"); ?>"><?php _e("Organizzazione e contatti", "design_scuole_italia"); ?></a>
@@ -244,6 +271,48 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                                         ?>
                                     </div><!-- /card-deck card-deck-spaced -->
                                 <?php } ?>
+
+
+
+
+                                <?php if((is_array($link_schede_documenti) && count($link_schede_documenti)>0) || (is_array($file_documenti) && count($file_documenti)>0)){
+                                    ?>
+                                    <h2 class="h4" id="art-par-documenti"><?php _e("Documenti", "design_scuole_italia"); ?></h2>
+                                    <div class="row variable-gutters">
+                                        <div class="col-lg-12">
+                                            <div class="card-deck card-deck-spaced">
+                                                <?php
+                                                if(is_array($link_schede_documenti) && count($link_schede_documenti)>0) {
+                                                    global $documento;
+                                                    foreach ( $link_schede_documenti as $link_scheda_documento ) {
+                                                        $documento = get_post( $link_scheda_documento );
+                                                        get_template_part( "template-parts/documento/card" );
+                                                    }
+                                                }
+
+                                                global $idfile, $nomefile;
+                                                if(is_array($file_documenti) && count($file_documenti)>0) {
+
+                                                    foreach ( $file_documenti as $idfile => $nomefile ) {
+                                                        get_template_part( "template-parts/documento/file" );
+                                                    }
+                                                }
+
+                                                ?>
+                                            </div><!-- /card-deck card-deck-spaced -->
+                                        </div><!-- /col-lg-12 -->
+                                    </div><!-- /row -->
+                                    <?php
+                                }?>
+
+
+
+
+
+
+
+
+
                                 <?php  if((is_array($responsabile) && count($responsabile)>0) || (is_array($persone) && count($persone)>0) || $altri_componenti != "" ||  $telefono || $mail || ( $post->post_parent == 0 && $children) || ($post->post_parent > 0)){  ?>
                                     <h2 id="art-par-organizzazione" class="h4"><?php _e("Organizzazione e contatti", "design_scuole_italia"); ?></h2>
 


### PR DESCRIPTION
Aggiunta opzione per associare i documenti alle strutture.

## Descrizione
La modifica, sulla falsariga di quanto già accade ad esempio per i servizi, consente di associare/inserire documenti nelle strutture organizzative (lato backend) e, nel caso siano presenti, di mostrarle nella pagina della singola struttura nel frontend.

Fixes: #375

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->