### PR TITLE
Correzione eliminazione gruppo utente dopo salvataggio

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -470,3 +470,12 @@ function insert_data_attribute_note_legali( $content ) {
 	else return $content; 
 	}
 add_filter('the_content', 'insert_data_attribute_note_legali');
+
+//redireziona gli utenti alla pagina iniziale dopo il login (se non sono impostati redirect)
+function dsi_login_redirect( $redirect_to, $request, $user ) {
+	// Senza impostare il redirect a 'wp-admin' (nonostante $redirect_to punti a quella pagina di default),
+	// gli utenti sottoscrittori che effetuano il login si ritroverebbero in /wp-admin/profile.php, che può essere disorientante.
+	return str_ends_with($redirect_to, '/wp-admin/') ? 'wp-admin' : $redirect_to;
+}
+
+add_filter( 'login_redirect', 'dsi_login_redirect', 10, 3 );

--- a/inc/extend-tax-to-user.php
+++ b/inc/extend-tax-to-user.php
@@ -174,24 +174,22 @@ class dsi_UserTaxonomies {
     }
 
     /**
-     * Save the custom user taxonomies when saving a users profile
+     * Save the custom user taxonomies when saving a user profile
      *
      * @param Integer $user_id	- The ID of the user to update
      */
     public function save_profile($user_id) {
-// svuoto
-        foreach(self::$taxonomies as $key=>$taxonomy) {
-            wp_set_object_terms($user_id, array(), $key, false);
-        }
+        if (!current_user_can('edit_user', $user_id))
+            return false;
 
         foreach(self::$taxonomies as $key=>$taxonomy) {
-            // Check the current user can edit this user and assign terms for this taxonomy
-            if(!current_user_can('edit_user', $user_id) && current_user_can($taxonomy->cap->assign_terms)) return false;
+            if(!current_user_can($taxonomy->cap->assign_terms))
+                continue;
 
             // Save the data
             $terms	= array_map(fn($term) => esc_html($term), $_POST[$key] ?? []);
             
-            wp_set_object_terms($user_id, $terms, $key, true);
+            wp_set_object_terms($user_id, $terms, $key);
             clean_object_term_cache($user_id, $key);
         }
     }


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Fixes #531 

Esiste un problema per cui un utente che modifica il proprio profilo elimina l'assegnazione ai gruppi utenti per visualizzare le circolari.
La modifica sistema questo problema, e fa in modo che al login l'utente venga reindirizzato alla bacheca e non alla pagina di modifica del profilo (a meno che non siano impostati altri redirect nell'url).

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->