### PR TITLE
Opzione utente per protezione privacy

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -479,10 +479,21 @@ function privacy_update( $user_id, $old_user_data) {
 	
 	preg_match_all('/\b\w/', $udata->last_name, $initials);
 	$new_last_name = implode('. ', $initials[0]);
+
 	if($new_last_name && $new_last_name != "") $new_last_name = $new_last_name . '.';
 	$partial_display_name = $udata->first_name . ' ' . $new_last_name;
 
-	if($force_privacy_partial_display == 'true' && $partial_display_name != $udata->display_name) {
+	if($force_privacy_partial_display == 'true' && $udata->display_name != $partial_display_name) {
 		$user_data = wp_update_user( array( 'ID' => $user_id, 'display_name' => $partial_display_name ) );
 	}
+
+	if($force_privacy_partial_display == 'false' && $udata->display_name == $partial_display_name) {
+		$default_display_name = $udata->username;
+
+		if($udata->first_name != "" && $udata->last_name != "")
+			$default_display_name =  $udata->first_name . ' ' . $udata->last_name;
+
+		$user_data = wp_update_user( array( 'ID' => $user_id, 'display_name' => $default_display_name ) );
+	}
 }
+add_action( 'profile_update', 'privacy_update', 10, 2 );

--- a/functions.php
+++ b/functions.php
@@ -470,3 +470,19 @@ function insert_data_attribute_note_legali( $content ) {
 	else return $content; 
 	}
 add_filter('the_content', 'insert_data_attribute_note_legali');
+
+// Forza cambiamento nome pubblico dell'utente in caso di privacy attiva
+function privacy_update( $user_id, $old_user_data) {
+	$udata = get_user_by( 'ID', $user_id );
+
+	$force_privacy_partial_display = get_user_meta( $user_id, '_dsi_persona_force_privacy_partial_display', true);
+	
+	preg_match_all('/\b\w/', $udata->last_name, $initials);
+	$new_last_name = implode('. ', $initials[0]);
+	if($new_last_name && $new_last_name != "") $new_last_name = $new_last_name . '.';
+	$partial_display_name = $udata->first_name . ' ' . $new_last_name;
+
+	if($force_privacy_partial_display == 'true' && $partial_display_name != $udata->display_name) {
+		$user_data = wp_update_user( array( 'ID' => $user_id, 'display_name' => $partial_display_name ) );
+	}
+}

--- a/inc/admin/persona.php
+++ b/inc/admin/persona.php
@@ -141,13 +141,30 @@ function dsi_add_persone_metaboxes() {
 	) );
 
 	$cmb_user->add_field( array(
+		'name'    => __( 'Protezione privacy', 'design_scuole_italia' ),
+		'id'      => $prefix . 'force_privacy_partial_display',
+		'desc'     => __( 'L\'opzione permette di visualizzare pubblicamente il cognome puntato. Attivandola, non &egrave; inoltre possibile impostare una foto profilo (non viene caricata neanche la foto da gravatar).' , 'design_scuole_italia' ),
+		'type'    => 'radio_inline',
+		'options'          => array(
+			'true' => __( 'Si', 'design_scuole_italia' ),
+			'false'     => __( 'No', 'design_scuole_italia' ),
+		),
+		'default' => 'false',
+		'attributes'    => array(
+			'required'    => 'required'
+		),
+	) );
+
+	$cmb_user->add_field( array(
 		'name'    => __( 'Foto della Persona', 'design_scuole_italia' ),
 		'desc'    => __( 'Inserire una fotografia che ritrae il soggetto descritto nella scheda', 'design_scuole_italia' ),
 		'id'      => $prefix . 'foto',
 		'type'    => 'file',
+		'attributes' => array(
+			'data-conditional-id'    => $prefix . 'force_privacy_partial_display',
+			'data-conditional-value' => 'false',
+		),
 	) );
-
-
 
 	$cmb_user->add_field( array(
 		'name'    => __( 'Ruolo nell\'organizzazione *', 'design_scuole_italia' ),

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -121,7 +121,7 @@ if(!function_exists("dsi_get_user_avatar")){
         
         $force_privacy_partial_display = get_user_meta( $user->ID, '_dsi_persona_force_privacy_partial_display', true);
         if($force_privacy_partial_display == "true")
-            return "";
+            return get_avatar_url( $user->ID, array("size" => $size, "force_default" => true) );
 
         $foto_id = null;
 		$foto_url = get_the_author_meta('_dsi_persona_foto', $user->ID);

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -118,6 +118,11 @@ if(!function_exists("dsi_get_user_avatar")){
 		if(!$user && is_user_logged_in()){
 			$user = wp_get_current_user();
 		}
+        
+        $force_privacy_partial_display = get_user_meta( $user->ID, '_dsi_persona_force_privacy_partial_display', true);
+        if($force_privacy_partial_display == "true")
+            return "";
+
         $foto_id = null;
 		$foto_url = get_the_author_meta('_dsi_persona_foto', $user->ID);
 		if($foto_url)
@@ -981,16 +986,9 @@ if(!function_exists("dsi_pluralize_string")) {
  * funzione per la gestione del nome autore
  */
 
-function dsi_get_display_name($user_id){
-
+ function dsi_get_display_name($user_id){
     $display = get_the_author_meta('display_name', $user_id);
-    $nome = get_the_author_meta('first_name', $user_id);
-    $cognome = get_the_author_meta('last_name', $user_id);
-    if(($nome != "") && ($cognome != ""))
-        return $nome." ".$cognome;
-    else
-        return $display;
-
+    return $display;
 }
 
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

- Aggiunta una nuova opzione per il singolo utente che permette di visualizzare pubblicamente il cognome puntato. Attivandola, non è inoltre possibile impostare una foto profilo (non viene caricata neanche la foto da gravatar).
- Corretta mancata visualizzazione del "Nome pubblico da visualizzare" nelle card dell'autore.

_Questo per dare una prima soluzione agli istituti il cui RPD (o DPO) richiede che la visualizzazione pubblica delle informazioni del personale ad eccezione di quelli apicali (es. dirigente) possa essere limitata. Al momento è stato puntato il cognome e rimossa la foto profilo._

Questa soluzione inoltre, funziona anche con il plugin https://github.com/WPGov/wp-spid-italia.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->