### PR TITLE
Visualizzazione dei progetti correlati nelle pagine dei luoghi

### DIFF
--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1355,6 +1355,16 @@ function dsi_register_main_options_metabox() {
         'escape_cb'       => 'absint',
     ) );
 
+    $luoghi_options->add_field( array(
+        'id' => $prefix . 'mostra_progetti_in_luogo',
+        'name'        => __( 'Mostra progetti correlati', 'design_scuole_italia' ),
+        'desc' => __('Mostra i progetti che si svolgono in un luogo nella pagina relativa a quel luogo, sotto la sezione "Ulteriori informazioni".', 'design_scuole_italia' ),
+        'type' => 'radio_inline',
+        'options' => array(
+            'true' => __('Si', 'design_scuole_italia'),
+            '' => __('No', 'design_scuole_italia'),
+        ),
+    ) );
 
     /**
      * Documenti

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -1198,3 +1198,45 @@ if(!function_exists("dsi_get_img_thumbnails")) {
         return $thumbnails;
     }
 }
+
+if(!function_exists("dsi_get_progetti_in_luogo")) {
+    /**
+     * Gets all scheda_progetto posts that are associated to the given luogo.
+     * @param int|string $luogo_id ID of luogo post
+     * @return WP_Post[] Array of scheda_progetto posts
+     */
+    function dsi_get_progetti_in_luogo($luogo_id)
+    {
+        $args = array(
+            'post_type' => 'scheda_progetto',
+            'numberposts' => -1,
+            'post_status' => 'publish',
+            'meta_query' => [
+                'relation' => 'AND',
+                [
+                    'key' => '_dsi_scheda_progetto_is_luogo_scuola',
+                    'value'   => 'true',
+                ],
+                [
+                    'relation' => 'OR',
+                    [
+                        'key' => '_dsi_scheda_progetto_link_schede_luoghi',
+                        'value'   => serialize(strval($luogo_id)), // Saved as string
+                        'compare' => 'LIKE'
+                    ],
+                    [
+                        'key' => '_dsi_scheda_progetto_link_schede_luoghi',
+                        'value'   => serialize(intval($luogo_id)), // Saved as integer. Could collide with serialized array indexes in the array
+                        'compare' => 'LIKE'
+                    ],
+                ]
+            ],
+        );
+        $progetti = get_posts($args);
+    
+        //filter progetti by checking that the luogo id is actually in the luoghi array and was not just an index collision in the query
+        $progetti = array_filter($progetti, fn ($progetto) => in_array($luogo_id, get_post_meta($progetto->ID, '_dsi_scheda_progetto_link_schede_luoghi', true)));
+    
+        return $progetti;
+    }
+}

--- a/single-luogo.php
+++ b/single-luogo.php
@@ -36,6 +36,9 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
         $altre_info = dsi_get_meta("info");
         $servizi_presenti = dsi_get_meta("servizi_presenti");
         $servizi_altro = dsi_get_meta("servizi_altro");
+        $progetti_presenti = dsi_get_progetti_in_luogo($post->ID);
+
+        $show_altre_info = trim($altre_info) || !empty($progetti_presenti);
 
         $modalita_accesso = dsi_get_meta("modalita_accesso");
         $gestito_da  = dsi_get_meta("gestito_da");
@@ -135,7 +138,7 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                                                 <a class="list-item scroll-anchor-offset" href="#art-par-gestione" title="Vai al paragrafo <?php _e("Gestito da", "design_scuole_italia"); ?>"><?php _e("Gestito da", "design_scuole_italia"); ?></a>
                                             </li>
                                         <?php } ?>
-                                        <?php if(trim($altre_info) != ""){ ?>
+                                        <?php if($show_altre_info){ ?>
                                             <li>
                                                 <a class="list-item scroll-anchor-offset" href="#art-par-altre-info" title="<?php _e("Vai al paragrafo", "design_scuole_italia"); ?> <?php _e("Ulteriori informazioni", "design_scuole_italia"); ?>"><?php _e("Ulteriori informazioni", "design_scuole_italia"); ?></a>
                                             </li>
@@ -416,13 +419,26 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                                 <?php } ?>
                                 <?php
 
-                                if(trim($altre_info) != ""){
+                                if($show_altre_info){
                                     ?>
                                     <h2 class="h4" id="art-par-altre-info"><?php _e("Ulteriori informazioni", "design_scuole_italia"); ?></h2>
                                     <div class="row variable-gutters">
                                         <div class="col-lg-9 wysiwig-text">
                                             <?php echo wpautop($altre_info); ?>
                                         </div><!-- /col-lg-9 -->
+
+                                        <?php if(!empty($progetti_presenti)){ ?>
+                                        <div class="col-lg-12">
+                                            <h3 class="h5">Progetti nel luogo</h3>
+                                            <div class="mt-3 card-deck card-deck-spaced">
+                                                <?php
+                                                foreach ( $progetti_presenti as $progetto ) {
+                                                    get_template_part("template-parts/progetto/card");
+                                                }
+                                                ?>
+                                            </div><!-- /card-deck card-deck-spaced -->
+                                        </div><!-- /col-lg-12 -->
+                                        <?php } ?>
                                     </div><!-- /row -->
                                     <?php
                                 }

--- a/single-luogo.php
+++ b/single-luogo.php
@@ -36,7 +36,9 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
         $altre_info = dsi_get_meta("info");
         $servizi_presenti = dsi_get_meta("servizi_presenti");
         $servizi_altro = dsi_get_meta("servizi_altro");
-        $progetti_presenti = dsi_get_progetti_in_luogo($post->ID);
+
+        $option_mostra_progetti = dsi_get_option("mostra_progetti_in_luogo", "luoghi") ?? false;
+        $progetti_presenti = $option_mostra_progetti ? dsi_get_progetti_in_luogo($post->ID) : [];
 
         $show_altre_info = trim($altre_info) || !empty($progetti_presenti);
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

La modifica mostra i progetti associati ad un luogo nella pagina relativa a quel luogo, quando l'apposita opzione nella configurazione dei luoghi è abilitata (quindi a meno di una modifica esplicita non ci saranno cambiamenti).

![image](https://github.com/italia/design-scuole-wordpress-theme/assets/13221786/b92861fd-a5b4-4d21-aead-e1a607a0f446)

I progetti appaiono nella sezione Ulteriori informazioni per non discostarsi troppo dall'alberatura corrente.

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->