### PR TITLE
Limitazione visualizzazione e accesso documenti albo scaduti e opzione per servizi di richiesta atti

### DIFF
--- a/inc/admin/documento.php
+++ b/inc/admin/documento.php
@@ -127,7 +127,7 @@ function dsi_add_documento_metaboxes() {
 
     $prefix = '_dsi_documento_';
 
-
+    $protect_from_public_access_extensions = dsi_get_option("protect_from_public_access_extensions", "setup");
 
 
     $cmb_annullato = new_cmb2_box( array(
@@ -194,6 +194,13 @@ function dsi_add_documento_metaboxes() {
         'id'             => $prefix . 'data_scadenza',
         'type'    => 'text_date_timestamp',
         'date_format' => 'd/m/Y',
+    ) );
+
+    $cmb_side->add_field( array(
+        'name' => 'Limita l\'accesso agli allegati dopo scadenza',
+        'desc' => 'Per limitare l\'accesso ai singoli allegati alla scadenza, assicurati che le estensioni dei file allegati siano presenti in <a href="admin.php?page=setup" target="_blank">Configurazione &gt; Altro</a> &gt; Estensioni protette dall\'accesso esterno. <br /><strong>' . ($protect_from_public_access_extensions != "" ? 'Estensioni attualmente protette: '. $protect_from_public_access_extensions : 'Nessuna estensione attualmente protetta') . '</strong>',
+        'type' => 'title',
+        'id'   => 'protect_file_ext_advice'
     ) );
 
     $cmb_sottotitolo = new_cmb2_box( array(
@@ -720,8 +727,28 @@ function dsi_check_documenti_daily() {
         )
     );
     $scaduti = get_posts($args);
+
+	$protect_from_public_access_extensions = dsi_get_option("protect_from_public_access_extensions", "setup");
+    $protected_extensions = explode(',', $protect_from_public_access_extensions);
+
     foreach ($scaduti as $item){
         $post = array( 'ID' => $item->ID, 'post_status' => "scaduto" );
+        if($protect_from_public_access_extensions && $protect_from_public_access_extensions != "") {
+            $file_documenti = get_post_meta( $item->ID, '_dsi_documento_file_documenti', true);
+
+            if (is_array($file_documenti) && count($file_documenti) > 0) { 
+                foreach($file_documenti as $url) {
+                    $attachment_id = attachment_url_to_postid($url);
+
+                    $ext = ".".pathinfo($url, PATHINFO_EXTENSION);
+
+                    if (in_array($ext, $protected_extensions)) {
+                        $protected = update_post_meta($attachment_id, 'protect_from_public_access', true);
+                    }
+                }
+            }
+        }
+
         wp_update_post($post);
     }
 

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1708,6 +1708,19 @@ function dsi_register_main_options_metabox() {
 		'type' => 'text'
     ) );
 
+    
+    $setup_options->add_field(array(
+        'id' => $prefix . 'show_contatore_commenti',
+        'name' => __('Mostra il contatore dei commenti', 'design_scuole_italia'),
+        'desc' => __('Seleziona <b>Si</b> per mostrare il numero dei commenti pubblicati', 'design_scuole_italia'),
+        'type' => 'radio_inline',
+        'default' => 'true',
+        'options' => array(
+            'true' => __('Si', 'design_scuole_italia'),
+            'false' => __('No', 'design_scuole_italia'),
+        ),
+    ));	
+
     $setup_options->add_field( array(
         'id' => $prefix . 'mail_circolari',
         'name'        => __( 'Configurazione email Circolari', 'design_scuole_italia' ),
@@ -1757,19 +1770,17 @@ function dsi_register_main_options_metabox() {
         'sanitization_cb' => 'dsi_sanitize_int',
         'escape_cb'       => 'dsi_sanitize_int',
     ) );
-	
-$setup_options->add_field(array(
-        'id' => $prefix . 'show_contatore_commenti',
-        'name' => __('Mostra il contatore dei commenti', 'design_scuole_italia'),
-        'desc' => __('Seleziona <b>Si</b> per mostrare il numero dei commenti pubblicati', 'design_scuole_italia'),
-        'type' => 'radio_inline',
-        'default' => 'true',
-        'options' => array(
-            'true' => __('Si', 'design_scuole_italia'),
-            'false' => __('No', 'design_scuole_italia'),
+    
+    $setup_options->add_field( array(
+        'id' => $prefix . 'servizi_richiesta_atti',
+        'name'        => __( 'Seleziona i servizi di richiesta atti', 'design_scuole_italia' ),
+        'desc' => __( 'Verranno mostrati in caso di atto scaduto. ' , 'design_scuole_italia' ),
+        'type'    => 'pw_multiselect',
+        'options' =>  dsi_get_servizi_options(),
+        'attributes' => array(
+            'placeholder' =>  __( 'Seleziona e ordina i servizi da mostrare', 'design_scuole_italia' ),
         ),
-    ));	
-
+    ) );
 }
 add_action( 'cmb2_admin_init', 'dsi_register_main_options_metabox' );
 

--- a/single-documento.php
+++ b/single-documento.php
@@ -203,7 +203,27 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                                         ?>
                                         <div class="row variable-gutters mb-4">
                                             <div class="col-lg-12">
-                                                <h5 class="text-redbrown"><?php _e("Allegati non disponibili - Albo Annullato", "design_scuole_italia"); ?></h5>
+                                                <h5 class="text-redbrown"><?php _e("Allegati non disponibili - Atto annullato", "design_scuole_italia"); ?></h5>
+                                            </div>
+                                        </div>
+                                        <?php
+                                    } else if (dsi_is_albo($post) && $post->post_status == "scaduto") {
+                                        $servizi_richiesta_atti = dsi_get_option("servizi_richiesta_atti", "setup");
+                                        ?>
+                                        <div class="row variable-gutters mb-4">
+                                            <div class="col-lg-12">
+                                                <h5 class="text-redbrown"><?php _e("Allegati non disponibili - Atto scaduto", "design_scuole_italia"); ?></h5>
+                                                <?php if (is_array($servizi_richiesta_atti) && count($servizi_richiesta_atti) > 0) { ?>
+                                                <p>Puoi richiedere il documento tramite <?php echo count($servizi_richiesta_atti) == 1 ? "il servizio dedicato" : "i servizi dedicati"; ?>.</p>
+                                                <div class="card-deck card-deck-spaced">
+                                                <?php foreach ($servizi_richiesta_atti as $idservizio){
+                                                    $servizio = get_post($idservizio);
+                                                    if($servizio) {
+                                                        get_template_part("template-parts/servizio/card");
+                                                    }
+                                                } ?>
+                                                </div>
+                                                <?php } ?>
                                             </div>
                                         </div>
                                         <?php


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Fino ad ora, anche dopo la scadenza di un atto in Albo online, risultavano scaricabili i documenti.
Con queste modifiche:
- non è più possibile visualizzare gli allegati di un atto di albo online se scaduto;
- in caso sia configurata l'opzione in Configurazione, alla scadenza, viene impostata l'opzione per limitare l'accesso al file con l'estensione protetta dall'esterno
- in caso l'atto sia scaduto, oltre a visualizzare un messaggio, vengono riportati gli eventuali servizi di richiesta atti.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->