### PR TITLE
Sostituito campo biografia con editor wysiwyg

### DIFF
--- a/inc/admin-js/persona-wysiwyg-bio.js
+++ b/inc/admin-js/persona-wysiwyg-bio.js
@@ -1,0 +1,2 @@
+  // Remove the biography field since a custom one is used (see persona.php)
+  jQuery("#description").parents("tr").remove();

--- a/inc/admin/persona.php
+++ b/inc/admin/persona.php
@@ -430,3 +430,57 @@ add_action( 'admin_print_scripts-profile.php', 'dsi_utente_admin_script', 11 );
 function dsi_utente_admin_script() {
 		wp_enqueue_script( 'utente-admin-script', get_template_directory_uri() . '/inc/admin-js/persona.js' );
 }
+
+/* WYSIWYG biography */
+function dsi_wysiwyg_bio($user)
+{
+	if (!current_user_can('edit_posts'))
+		return;
+?>
+	<table class="form-table">
+		<tr>
+			<th><label for="description"><?php _e('Biographical Info'); ?></label></th>
+			<td>
+				<?php
+				$description = get_user_meta($user->ID, 'description', true);
+				wp_editor($description, 'description');
+				?>
+				<p class="description"><?php _e('Share a little biographical information to fill out your profile. This may be shown publicly.'); ?></p>
+			</td>
+		</tr>
+	</table>
+<?php
+}
+add_action('show_user_profile', 'dsi_wysiwyg_bio');
+add_action('edit_user_profile', 'dsi_wysiwyg_bio');
+
+
+function dsi_wysiwyg_bio_save_filters()
+{
+	if (!current_user_can('edit_posts'))
+		return;
+	remove_all_filters('pre_user_description');
+}
+add_action('admin_init', 'dsi_wysiwyg_bio_save_filters');
+
+function dsi_wysiwyg_bio_load_js( $hook ) {
+	if ( !current_user_can('edit_posts') )
+		return;
+
+	if ( $hook == 'profile.php' || $hook == 'user-edit.php' ) {
+		wp_enqueue_script(
+			'wysiwyg-bio-admin-script', 
+			get_template_directory_uri() . '/inc/admin-js/persona-wysiwyg-bio.js', 
+			array('jquery'), 
+			false, 
+			true
+		);
+	}
+}
+add_action( 'admin_enqueue_scripts', 'dsi_wysiwyg_bio_load_js', 10, 1 );
+
+add_filter('get_the_author_description', 'wptexturize');
+add_filter('get_the_author_description', 'convert_chars');
+add_filter('get_the_author_description', 'wpautop');
+
+/* end WYSIWYG biography */


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

Il campo "Informazioni biografiche" delle persone (utenti) è stato sostituito con un campo di editing avanzato (wysiwyg), per fornire supporto a elementi come paragrafi, immagini e formattazione.

La modifica è stata effettuata in seguito alla richiesta da parte di un istituto di inserire una biografia piuttosto lunga del dirigente scolastico. Il campo di testo semplice di WordPress per la biografia non permette di inserire paragrafi e nuove righe, di conseguenza nel front-end il testo risultava poco fruibile.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->