### PR TITLE
Immagine nei link condivisi

### DIFF
--- a/header.php
+++ b/header.php
@@ -21,9 +21,19 @@ $theme_locations = get_nav_menu_locations();
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
 
-	<?php if (dsi_get_option("favicon_scuola")) { ?>
-		<link rel="icon" type="image/x-icon" href="<?php echo dsi_get_option("favicon_scuola");?>">
-	<?php } ?>
+    <?php
+    $og_image_url = get_the_post_thumbnail_url() ?: $url_favicon; // Tag Open Graph per l'immagine di copertina nei link condivisi (es: Facebook)
+
+    if ($og_image_url) { ?>
+        <meta property="og:image" content="<?= $og_image_url ?>">
+        <?php
+        $og_image_url_alt = get_post_meta(attachment_url_to_postid($og_image_url), '_wp_attachment_image_alt', true);
+
+        if ($og_image_url_alt) { ?>
+            <meta property="og:image:alt" content="<?= $og_image_url_alt ?>">
+    <?php }
+    }
+    ?>
     
 	<?php wp_head(); ?>
 </head>

--- a/header.php
+++ b/header.php
@@ -20,9 +20,17 @@ $theme_locations = get_nav_menu_locations();
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
+    <?php if ($favicon_url = dsi_get_option("favicon_scuola")) { ?>
+		<link rel="icon" type="image/x-icon" href="<?= $favicon_url ?>">
+	<?php } 
 
-    <?php
-    $og_image_url = get_the_post_thumbnail_url() ?: $url_favicon; // Tag Open Graph per l'immagine di copertina nei link condivisi (es: Facebook)
+    // Tag Open Graph per l'immagine di copertina nei link condivisi (es: Facebook)
+    $cover_image_url = dsi_get_option("immagine", "la_scuola");
+    $thumbnail_url = get_the_post_thumbnail_url();
+
+    $home_image_url = $cover_image_url ?: $favicon_url;
+
+    $og_image_url = is_front_page() ? $home_image_url : ($thumbnail_url ?: $home_image_url);
 
     if ($og_image_url) { ?>
         <meta property="og:image" content="<?= $og_image_url ?>">


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Con questa modifica, l'header contiene dei tag Open Graph che suggeriscono a Facebook e siti simili di l'immagine da usare nella condivisione dei link.

Ciò è stato fatto in seguito alla segnalazione di una scuola del fatto che condividendo i link del sito su Facebook l'immagine  ("pescata" da Facebook) vicino al link non fosse pertinente.

In particolare, l'immagine suggerita per i link di condivisione dei post sarà l'immagine in evidenza (la thumbnail); altrimenti, se il link porta alla home del sito o se è assente un'immagine in evidenza verrà usata l'immagine di presentazione della scuola, se è assente anche questa verrà usata la favicon.

Per verificare la resa dei link condivisi è possibile usare lo strumento messo a disposizione da Facebook: [Debugger di condivisione](https://developers.facebook.com/tools/debug/)

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->