### PR TITLE
Corretta errata visualizzazione mappa vuota negli eventi

### DIFF
--- a/template-parts/luogo/card-custom.php
+++ b/template-parts/luogo/card-custom.php
@@ -12,6 +12,8 @@ if (dsi_get_meta("circoscrizione_luogo_custom") != "")
 	$arrq[] = dsi_get_meta("circoscrizione_luogo_custom");
 ?>
 
+
+
 <div class="card card-bg rounded mb-5">
 	<div class="card-header">
 		<strong class="d-block"><?php echo  $nome_luogo_custom; ?></strong>
@@ -21,14 +23,16 @@ if (dsi_get_meta("circoscrizione_luogo_custom") != "")
 	<div class="card-body p-0">
 		<div class="row variable-gutters">
 			<div class="col-lg-12">
+			<?php if ($posizione_gps["lat"]) { ?>
 				<div class="map-wrapper map-min-height">
 					<div class="map" id="map_<?php echo $c; ?>"></div>
 				</div>
+			<?php } ?>	
 			</div><!-- /col-lg-12 -->
 		</div><!-- /row -->
 	</div><!-- /card-body -->
 </div><!-- /card card-bg rounded -->
-
+<?php if ($posizione_gps["lat"]) { ?>
 <script>
 	window.addEventListener('load', function() {
 		var mymap = L.map('map_<?php echo $c; ?>', {
@@ -45,3 +49,4 @@ if (dsi_get_meta("circoscrizione_luogo_custom") != "")
 		}).addTo(mymap);
 	});
 </script>
+<?php } ?>

--- a/template-parts/luogo/card-custom.php
+++ b/template-parts/luogo/card-custom.php
@@ -12,8 +12,6 @@ if (dsi_get_meta("circoscrizione_luogo_custom") != "")
 	$arrq[] = dsi_get_meta("circoscrizione_luogo_custom");
 ?>
 
-
-
 <div class="card card-bg rounded mb-5">
 	<div class="card-header">
 		<strong class="d-block"><?php echo  $nome_luogo_custom; ?></strong>


### PR DESCRIPTION
Corretta errata visualizzazione mappa vuota negli eventi

## Descrizione
Quando il luogo inserito manualmente in un evento non ha una posizione GPS definita nel backend, il contenitore della mappa nel frontend veniva mostrato lo stesso vuoto. Con la modifica apportata si risolve il problema.

Fixes #641

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->