### PR TITLE
Aggiunta opzioni per modulo login

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Cliccando su “Configurazione" è possibile definire:
 -	**organizzazione**: area di configurazione della pagina di presentazione dell’organizzazione scolastica, tramite la selezione delle strutture organizzative da mostrare;
 -	**luoghi**: area in cui configurare la tipologia e l’ordine delle tipologie di luoghi da mostrare;
 -	**documenti**: area di configurazione dei documenti, organizzati in base alle tipologie selezionate;
--	**servizi esterni**: area per configurare i servizi esterni alla scuola da mostrare nella modale di accesso (registro elettronico o altri);
+-	**accesso ai servizi**: area per configurare i servizi esterni alla scuola da mostrare nella modale di accesso (registro elettronico o altri) e le informazioni del modulo di login all'area riservata di Wordpress;
 -	**socialmedia**: collegamenti ai social mostrati nell'intestazione e nel piè di pagina.
 -	**altro**: la descrizione della sezione Argomenti, i contenuti ulteriori del piè di pagina, il token mapbox (da creare per utilizzare le mappe openstreetmap dei luoghi), la configurazione delle estensioni protette dall'accesso esterno, il testo delle mail delle circolari e il setup della sezione albo.
 

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1505,7 +1505,7 @@ function dsi_register_main_options_metabox() {
 	$login_options->add_field( array(
 		'id' => $prefix . 'login_title',
 		'name' => 'Titolo per il modulo di login',
-		'desc' => __( 'Titolo visualizzato nella sezione di accesso all\'area riservata di Wordpress, nella maschera di login (Se non compilato, viene valorizzato con "Personale scolastico")', 'design_scuole_italia' ),
+		'desc' => __( 'Titolo visualizzato nella sezione di accesso all\'area riservata di Wordpress (se non compilato viene mostrato "Personale scolastico")', 'design_scuole_italia' ),
 		'type' => 'text',
         'default' => 'Personale scolastico',
     ) );

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1514,7 +1514,7 @@ function dsi_register_main_options_metabox() {
 	$login_options->add_field( array(
 		'id' => $prefix . 'login_desc',
 		'name' => 'Descrizione per il modulo di login',
-		'desc' => __( 'Introduzione visualizzata nella sezione di accesso all\'area riservata di Wordpress, nella maschera di login (Se non compilato, viene valorizzato con "Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.")', 'design_scuole_italia' ),
+		'desc' => __( 'Introduzione visualizzata nella sezione di accesso all\'area riservata di Wordpress (se non compilato, viene mostrato "Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.")', 'design_scuole_italia' ),
 		'type' => 'text',
         'default' => 'Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.',
     ) );

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1498,7 +1498,7 @@ function dsi_register_main_options_metabox() {
     $login_options->add_field( array(
         'id' => $prefix . 'login_istruzioni',
         'name'        => __( 'Area riservata di Wordpress', 'design_scuole_italia' ),
-        'desc' => __( 'Area di configurazione della sezione di accesso all\'area riservata di Wordpress, da mostrare nella maschera di login.' , 'design_scuole_italia' ),
+        'desc' => __( 'Configurazione della sezione di accesso all\'area riservata di Wordpress.' , 'design_scuole_italia' ),
         'type' => 'title',
     ) );
 

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1514,7 +1514,7 @@ function dsi_register_main_options_metabox() {
 	$login_options->add_field( array(
 		'id' => $prefix . 'login_desc',
 		'name' => 'Descrizione per il modulo di login',
-		'desc' => __( 'Introduzione visualizzata nella sezione di accesso all\'area riservata di Wordpress (se non compilato, viene mostrato "Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.")', 'design_scuole_italia' ),
+		'desc' => __( 'Introduzione presente nella sezione di accesso all\'area riservata di Wordpress (se non compilato, viene mostrato "Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.")', 'design_scuole_italia' ),
 		'type' => 'text',
         'default' => 'Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.',
     ) );

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1505,7 +1505,7 @@ function dsi_register_main_options_metabox() {
 	$login_options->add_field( array(
 		'id' => $prefix . 'login_title',
 		'name' => 'Titolo per il modulo di login',
-		'desc' => __( 'Titolo visualizzato nella sezione di accesso all\'area riservata di Wordpress (se non compilato viene mostrato "Personale scolastico")', 'design_scuole_italia' ),
+		'desc' => __( 'Titolo presente nella sezione di accesso all\'area riservata di Wordpress (se non compilato viene mostrato "Personale scolastico")', 'design_scuole_italia' ),
 		'type' => 'text',
         'default' => 'Personale scolastico',
     ) );

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1440,7 +1440,7 @@ function dsi_register_main_options_metabox() {
         'title'        => esc_html__( 'Login', 'design_scuole_italia' ),
         'object_types' => array( 'options-page' ),
         'option_key'   => 'login',
-        'tab_title'    => __('Servizi esterni', "design_scuole_italia"),
+        'tab_title'    => __('Accesso ai servizi', "design_scuole_italia"),
         'parent_slug'  => 'dsi_options',
         'tab_group'    => 'dsi_options',
         'capability'    => 'manage_options',
@@ -1454,15 +1454,15 @@ function dsi_register_main_options_metabox() {
     $login_options = new_cmb2_box( $args );
 
     $login_options->add_field( array(
-        'id' => $prefix . 'login_istruzioni',
-        'name'        => __( 'Servizi esterni: informazioni di login', 'design_scuole_italia' ),
+        'id' => $prefix . 'link_esterni_istruzioni',
+        'name'        => __( 'Servizi esterni', 'design_scuole_italia' ),
         'desc' => __( 'Area di configurazione dei link di login ai servizi esterni, da mostrare nella maschera di login .' , 'design_scuole_italia' ),
         'type' => 'title',
     ) );
-
+    
     $login_options->add_field( array(
         'id' => $prefix . 'login_messaggio',
-        'name' => 'Testo da mostrare nell\'area di login',
+        'name' => 'Introduzione alla lista dei servizi esterni',
         'type' => 'textarea',
         'default' => 'Da qui puoi accedere ai diversi servizi della scuola che richiedono una autenticazione personale.',
     ) );
@@ -1494,6 +1494,30 @@ function dsi_register_main_options_metabox() {
         'type' => 'text_url',
     ) );
 
+    
+    $login_options->add_field( array(
+        'id' => $prefix . 'login_istruzioni',
+        'name'        => __( 'Area riservata di Wordpress', 'design_scuole_italia' ),
+        'desc' => __( 'Area di configurazione della sezione di accesso all\'area riservata di Wordpress, da mostrare nella maschera di login.' , 'design_scuole_italia' ),
+        'type' => 'title',
+    ) );
+
+	$login_options->add_field( array(
+		'id' => $prefix . 'login_title',
+		'name' => 'Titolo per il modulo di login',
+		'desc' => __( 'Titolo visualizzato nella sezione di accesso all\'area riservata di Wordpress, nella maschera di login (Se non compilato, viene valorizzato con "Personale scolastico")', 'design_scuole_italia' ),
+		'type' => 'text',
+        'default' => 'Personale scolastico',
+    ) );
+
+    
+	$login_options->add_field( array(
+		'id' => $prefix . 'login_desc',
+		'name' => 'Descrizione per il modulo di login',
+		'desc' => __( 'Introduzione visualizzata nella sezione di accesso all\'area riservata di Wordpress, nella maschera di login (Se non compilato, viene valorizzato con "Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.")', 'design_scuole_italia' ),
+		'type' => 'text',
+        'default' => 'Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.',
+    ) );
 
     /**
      * Registers options page "Socials".

--- a/template-parts/common/access-modal.php
+++ b/template-parts/common/access-modal.php
@@ -33,8 +33,12 @@
                             </div>
                             <div class="col-lg-4 offset-lg-2 access-mobile-bg">
                                 <div class="access-login">
-                                    <h3><?php _e("Personale scolastico", "design_scuole_italia"); ?></h3>
-                                    <p class="text-large"><?php _e("Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.", "design_scuole_italia"); ?></p>
+                                    <?php
+                                        $login_title = dsi_get_option("login_title", "login");
+                                        $login_description = dsi_get_option("login_desc", "login");
+                                    ?>
+                                    <h3><?php $login_title ? _e($login_title) :  _e("Personale scolastico", "design_scuole_italia"); ?></h3>
+                                    <p class="text-large"><?php $login_description ? _e($login_description) : _e("Entra nel sito della scuola con le tue credenziali per gestire contenuti, visualizzare circolari e altre funzionalità.", "design_scuole_italia"); ?></p>
                                     <?php if(in_array('wp-spid-italia/wp-spid-italia.php', apply_filters('active_plugins', get_option('active_plugins')))){?>
                                         <div class="col text-center pt-4">
                                             <?php echo do_shortcode("[spid_login_button]"); ?>


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
- Ridenominata scheda configurazione "Servizi esterni" in "Accesso ai servizi" e inserimento area "Area riservata di Wordpress"
- Opzioni "Titolo per il modulo di login" e "Descrizione per il modulo di login" per configurare le informazioni visualizzate nella modale di accesso

Fixes #376 

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->