### PR TITLE
Fix warning php in caso di mancanza ID foto profilo nell'intestazione (logged)

### DIFF
--- a/template-parts/header/header-logged.php
+++ b/template-parts/header/header-logged.php
@@ -18,6 +18,7 @@ if($last_notification){
 }
 
 $foto_url = get_the_author_meta('_dsi_persona_foto', $current_user->ID);
+$image_id = null;
 if($foto_url)
     $image_id = attachment_url_to_postid($foto_url);
 $image_url = dsi_get_user_avatar($current_user);


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Come da titolo, corretto warning php in caso di mancanza ID foto profilo nell'intestazione (logged)
Versione PHP installata: 8.2.18

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->