### PR TITLE
Ordinamento personalizzato per progetti

### DIFF
--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1171,7 +1171,7 @@ function dsi_register_main_options_metabox() {
         ),
     ) );
 
-    $progetti_landing_url = dsi_get_template_page_url("page-templates/progetti.php");
+    $progetti_landing_url = get_post_type_archive_link("scheda-progetto");
     $didattica_options->add_field( array(
         'id' => $prefix . 'progetti_istruzioni',
         'name'        => __( 'Sezione Progetti', 'design_scuole_italia' ),
@@ -1186,7 +1186,7 @@ function dsi_register_main_options_metabox() {
         'type'             => 'select',
         'default'          => 'realizzato',
         'options'          => array(
-            'realizzato'       => __('Realizzato', 'design_scuole_italia'),
+            'realizzato'       => __('Realizzato / non realizzato', 'design_scuole_italia'),
             'anno_scolastico'  => __('Anno scolastico', 'design_scuole_italia'),
             'date'             => __('Data di pubblicazione', 'design_scuole_italia'),
             'timestamp_inizio' => __('Data di inizio del progetto', 'design_scuole_italia'),
@@ -1197,7 +1197,7 @@ function dsi_register_main_options_metabox() {
 
     $didattica_options->add_field(array(
         'name'             => __("Direzione dell'ordinamento", 'design_scuole_italia'),
-        'desc'             => __('Scegli se ordinare i progetti in ordine crescente o descrescente (se l\'ordine è in base a "Realizzato", l\'opzione "Decrescente" mostra prima i progetti realizzati).', 'design_scuole_italia'),
+        'desc'             => __('Scegli se ordinare i progetti in ordine crescente o descrescente (se l\'ordine è in base a "Realizzato / non realizzato", l\'opzione "Decrescente" mostra prima i progetti realizzati).', 'design_scuole_italia'),
         'id'               => $prefix . 'direzione_ordinamento_progetti',
         'type'             => 'radio_inline',
         'options'          => array(

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1171,7 +1171,7 @@ function dsi_register_main_options_metabox() {
         ),
     ) );
 
-    $progetti_landing_url = get_post_type_archive_link("scheda-progetto");
+    $progetti_landing_url = get_post_type_archive_link("scheda_progetto");
     $didattica_options->add_field( array(
         'id' => $prefix . 'progetti_istruzioni',
         'name'        => __( 'Sezione Progetti', 'design_scuole_italia' ),

--- a/inc/admin/options.php
+++ b/inc/admin/options.php
@@ -1171,7 +1171,41 @@ function dsi_register_main_options_metabox() {
         ),
     ) );
 
+    $progetti_landing_url = dsi_get_template_page_url("page-templates/progetti.php");
+    $didattica_options->add_field( array(
+        'id' => $prefix . 'progetti_istruzioni',
+        'name'        => __( 'Sezione Progetti', 'design_scuole_italia' ),
+        'desc' => __( 'Inserisci qui le informazioni utili a popolare <a href="'.$progetti_landing_url.'">la pagina di panoramica dei progetti</a>.' , 'design_scuole_italia' ),
+        'type' => 'title',
+    ) );
 
+    $didattica_options->add_field(array(
+        'name'             => __('Ordinamento dei progetti', 'design_scuole_italia'),
+        'desc'             => __('Scegli il criterio in base a cui ordinare i progetti nella pagina di panoramica.', 'design_scuole_italia'),
+        'id'               => $prefix . 'ordinamento_progetti',
+        'type'             => 'select',
+        'default'          => 'realizzato',
+        'options'          => array(
+            'realizzato'       => __('Realizzato', 'design_scuole_italia'),
+            'anno_scolastico'  => __('Anno scolastico', 'design_scuole_italia'),
+            'date'             => __('Data di pubblicazione', 'design_scuole_italia'),
+            'timestamp_inizio' => __('Data di inizio del progetto', 'design_scuole_italia'),
+            'timestamp_fine'   => __('Data di fine del progetto', 'design_scuole_italia'),
+            'title'            => __('Titolo', 'design_scuole_italia'),
+        ),
+    ));
+
+    $didattica_options->add_field(array(
+        'name'             => __("Direzione dell'ordinamento", 'design_scuole_italia'),
+        'desc'             => __('Scegli se ordinare i progetti in ordine crescente o descrescente (se l\'ordine è in base a "Realizzato", l\'opzione "Decrescente" mostra prima i progetti realizzati).', 'design_scuole_italia'),
+        'id'               => $prefix . 'direzione_ordinamento_progetti',
+        'type'             => 'radio_inline',
+        'options'          => array(
+            'desc'             => __('Decrescente', 'cmb2'),
+            'asc'              => __('Crescente', 'cmb2'),
+        ),
+        'default' => 'desc',
+    ));
 
 /*
     $didattica_options->add_field( array(


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

In seguito alla richiesta di una scuola di vedere i progetti in ordine di inserimento anziché come realizzati e non realizzati, sono state create delle opzioni nella sezione Didattica che permettono di ordinare i progetti secondo il criterio scelto.

I criteri sono:
- Realizzato / non realizzato
- Anno scolastico
- Data di pubblicazione
- Inizio progetto
- Fine progetto
- Titolo

Inoltre, è possibile scegliere la direzione di ordinamento.

![image](https://github.com/italia/design-scuole-wordpress-theme/assets/13221786/95eae86f-2a60-46f0-87a1-ca184e597346)

Il comportamento dei siti attuali non verrà modificato, a meno di azioni esplicite nelle impostazioni.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->