### PR TITLE
Tipologia circolare e tipologia documento in header

### DIFF
--- a/single-circolare.php
+++ b/single-circolare.php
@@ -139,16 +139,6 @@ $file_documenti = dsi_get_meta("file_documenti");
                                     ?>
                                 </div><!-- /cards-avatar -->
                             <?php } */ ?>
-				<aside class="badges-wrapper badges-main mt-4">
-					<?php $post_tags = get_the_terms(get_the_ID(), 'tipologia-circolare');
-						if ($post_tags) {
-							echo '<h2 class="h4">Tipologia</h2>';
-							foreach($post_tags as $tag) {
-                                echo '<a href="'.get_tag_link($tag->term_id).'" class="badge badge-sm badge-pill badge-outline-greendark" aria-label="Tipologia: '.$tag->name.'">'. $tag->name .'</a><br>';
-							}
-						}
-					?>
-				</aside>		
                         </div><!-- /col-lg-3 -->
                     </div><!-- /row -->
 

--- a/single-documento.php
+++ b/single-documento.php
@@ -48,8 +48,16 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                         </div><!-- /col-lg-2 -->
                         <div class="col-12 col-sm-9 col-lg-5 col-md-8">
                             <div class="section-title">
-                                <?php if(dsi_is_albo($post) && $numerazione_albo){ ?>
-                                    <small class="h6 text-redbrown"><?php echo $numerazione_albo; ?></small>
+                                <?php if ($post_tags = get_the_terms(get_the_ID(), 'tipologia-documento')) {
+                                    $count = 0;
+                                    foreach ($post_tags as $tag) {
+                                        echo $count++ ? ' - ' : '';
+                                ?>
+                                        <a href="<?= get_tag_link($tag->term_id) ?>" class="h6 text-redbrown" aria-label="Tipologia: <?= $tag->name ?>"><?= $tag->name ?></a>
+                                <?php }
+                                } ?>
+                                <?php if (dsi_is_albo($post) && $numerazione_albo) { ?>
+                                    <p class="h5 mb-1 mt-1"><?= $numerazione_albo ?></p>
                                 <?php } ?>
                                 <h1 class="h2 mb-3"><?php the_title(); ?></h1>
                                 <p><?php if(!post_password_required()) echo dsi_get_meta( "descrizione" ); ?></p>
@@ -63,17 +71,7 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                             <?php
                                 $badgeclass = "badge-outline-redbrown";
                                 get_template_part( "template-parts/common/badges-argomenti" ); 
-                            ?>
-                        <div class="badges-wrapper badges-main mt-4">
-                            <?php $post_tags = get_the_terms(get_the_ID(), 'tipologia-documento');
-                                if ($post_tags) {
-                                    echo '<h2 class="h4">Tipologia</h2>';
-                                    foreach($post_tags as $tag) {
-                                        echo '<a href="'.get_tag_link($tag->term_id).'" class="badge badge-sm badge-pill badge-outline-redbrown" aria-label="Tipologia: '.$tag->name.'">'. $tag->name .'</a> ';
-                                    }
-                                }
-                            ?>
-				        </div>		
+                            ?>	
                     </div><!-- /col-lg-3 col-md-4 offset-lg-1 -->
                 </div><!-- /row -->
                 </div><!-- /container -->

--- a/single-documento.php
+++ b/single-documento.php
@@ -53,7 +53,7 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                                     foreach ($post_tags as $tag) {
                                         echo $count++ ? ' - ' : '';
                                 ?>
-                                        <a href="<?= get_tag_link($tag->term_id) ?>" class="h6 text-redbrown" aria-label="Tipologia: <?= $tag->name ?>"><?= $tag->name ?></a>
+                                        <a href="<?= get_tag_link($tag->term_id) ?>" class="h6 text-redbrown text-uppercase" aria-label="Tipologia: <?= $tag->name ?>"><?= $tag->name ?></a>
                                 <?php }
                                 } ?>
                                 <?php if (dsi_is_albo($post) && $numerazione_albo) { ?>

--- a/template-parts/single/header-circolare.php
+++ b/template-parts/single/header-circolare.php
@@ -29,7 +29,7 @@ $autore = get_user_by("ID", $post->post_author);
                     <?php $post_tags = get_the_terms(get_the_ID(), 'tipologia-circolare');
 						if ($post_tags) {
 							foreach($post_tags as $tag) { ?>
-                                <a class="h4 mb-3 text-greendark d-block" href="<?= get_tag_link($tag->term_id) ?>" aria-label="Tipologia: <?= $tag->name ?>"><?= $tag->name ?></a>
+                                <a class="h4 mb-3 text-greendark text-uppercase d-block" href="<?= get_tag_link($tag->term_id) ?>" aria-label="Tipologia: <?= $tag->name ?>"><?= $tag->name ?></a>
 							<?php }
 						}
 					?>

--- a/template-parts/single/header-circolare.php
+++ b/template-parts/single/header-circolare.php
@@ -29,7 +29,7 @@ $autore = get_user_by("ID", $post->post_author);
                     <?php $post_tags = get_the_terms(get_the_ID(), 'tipologia-circolare');
 						if ($post_tags) {
 							foreach($post_tags as $tag) { ?>
-                                <a class="h4 mb-3 text-greendark text-uppercase d-block" href="<?= get_tag_link($tag->term_id) ?>" aria-label="Tipologia: <?= $tag->name ?>"><?= $tag->name ?></a>
+                                <a class="h4 mb-3 text-greendark d-block" href="<?= get_tag_link($tag->term_id) ?>" aria-label="Tipologia: <?= $tag->name ?>"><?= $tag->name ?></a>
 							<?php }
 						}
 					?>

--- a/template-parts/single/header-circolare.php
+++ b/template-parts/single/header-circolare.php
@@ -26,6 +26,13 @@ $autore = get_user_by("ID", $post->post_author);
                 <small class="h6 text-greendark"><?php _e("Circolare ", "design_scuole_italia"); echo $numerazione_circolare; ?></small>
                 <div class="section-title">
                     <h1 class="h2"><?php the_title(); ?></h1>
+                    <?php $post_tags = get_the_terms(get_the_ID(), 'tipologia-circolare');
+						if ($post_tags) {
+							foreach($post_tags as $tag) { ?>
+                                <a class="h4 mb-3 text-greendark d-block" href="<?= get_tag_link($tag->term_id) ?>" aria-label="Tipologia: <?= $tag->name ?>"><?= $tag->name ?></a>
+							<?php }
+						}
+					?>
                     <p><?php echo dsi_get_meta("descrizione"); ?></p>
                 </div><!-- /title-section -->
             </div><!-- /col-lg-5 col-md-8 -->


### PR DESCRIPTION
## Descrizione

La tipologia del documento e la tipologia della circolare vengono mostrati nell'header della pagina, vicino titolo (e vengono rimosse dalla barra laterale).

![image](https://github.com/italia/design-scuole-wordpress-theme/assets/13221786/ce03ad80-e66e-4b46-b6e3-b62f00b0ed53)

![image](https://github.com/italia/design-scuole-wordpress-theme/assets/13221786/83152761-66e4-45e7-b5a2-d283dfcdfbb5)

Questa modifica rende efficaci le modifiche accettate nella repository delle [pagine statiche](https://github.com/italia/design-scuole-pagine-statiche/pull/62).

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).