### PR TITLE
Supporto per il campo "autore" nelle circolari

### DIFF
--- a/inc/admin/circolare.php
+++ b/inc/admin/circolare.php
@@ -17,7 +17,7 @@ function dsi_register_circolare_post_type()
     $args = array(
         'label' => __('Circolare', 'design_scuole_italia'),
         'labels' => $labels,
-        'supports' => array('title', 'editor'),
+        'supports' => array('title', 'editor', 'author'),
         'taxonomies' => array('post_tag'),
         'hierarchical' => false,
         'public' => true,


### PR DESCRIPTION
## Descrizione
La modifica aggiunge il supporto della funzionalità di selezione dell'autore di WordPress per le circolari. Questa modifica proviene dalla necessità di un istituto di indicare un autore della circolare diverso da quello che effettua il caricamento, in modo che l'autore visualizzato nella pagina della circolare sia corretto.

Questo comportamento, inoltre, si allinea a quello delle notizie, in cui è già possibile selezionare l'autore.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->