### PR TITLE
Link ai video nella galleria multimediale

### DIFF
--- a/inc/admin/documento.php
+++ b/inc/admin/documento.php
@@ -348,10 +348,10 @@ function dsi_add_documento_metaboxes() {
     $cmb_aftercontent->add_field( array(
         'id'         => $prefix . 'gallery',
         'name'       => __( 'Galleria', 'design_scuole_italia' ),
-        'desc'       => __( 'Galleria di immagini  significative relative a un documento, corredate da didascalia', 'design_scuole_italia' ),
+        'desc'       => __( 'Galleria di immagini o video significativi relativi a un documento, corredate da didascalia (per i video, verrà mostrata una copertina che corrisponde all\'immagine in evidenza del video, che si può impostare nella sezione "Media" di WordPress; se assente, verrà usata l\'immagine in evidenza del post).', 'design_scuole_italia' ),
         'type' => 'file_list',
         // 'preview_size' => array( 100, 100 ), // Default: array( 50, 50 )
-        'query_args' => array( 'type' => 'image' ), // Only images attachment
+        'query_args' => array( 'type' => ['image', 'video'] ), // Only images or videos attachment
     ) );
 
 

--- a/inc/admin/evento.php
+++ b/inc/admin/evento.php
@@ -255,10 +255,10 @@ function dsi_add_eventi_metaboxes() {
 	$cmb_undercontent->add_field( array(
 		'id'         => $prefix . 'gallery',
 		'name'       => __( 'Galleria', 'design_scuole_italia' ),
-		'desc'       => __( 'Galleria di immagini', 'design_scuole_italia' ),
+		'desc'       => __( 'Galleria di immagini o video (per i video, verrà mostrata una copertina che corrisponde all\'immagine in evidenza del video, che si può impostare nella sezione "Media" di WordPress; se assente, verrà usata l\'immagine in evidenza del post)', 'design_scuole_italia' ),
 		'type' => 'file_list',
 		// 'preview_size' => array( 100, 100 ), // Default: array( 50, 50 )
-		'query_args' => array( 'type' => 'image' ), // Only images attachment
+        'query_args' => array( 'type' => ['image', 'video'] ), // Only images or videos attachment
 	) );
 
 	$cmb_undercontent->add_field( array(

--- a/inc/admin/luogo.php
+++ b/inc/admin/luogo.php
@@ -357,10 +357,10 @@ function dsi_add_luogo_metaboxes() {
 	$cmb_aftercontent_luoghi->add_field( array(
 		'id'         => $prefix . 'gallery',
 		'name'       => __( 'Galleria', 'design_scuole_italia' ),
-		'desc'       => __( 'Galleria di immagini', 'design_scuole_italia' ),
+		'desc'       => __( 'Galleria di immagini o video (per i video, verrà mostrata una copertina che corrisponde all\'immagine in evidenza del video, che si può impostare nella sezione "Media" di WordPress; se assente, verrà usata l\'immagine in evidenza del post)', 'design_scuole_italia' ),
 		'type' => 'file_list',
 		// 'preview_size' => array( 100, 100 ), // Default: array( 50, 50 )
-		'query_args' => array( 'type' => 'image' ), // Only images attachment
+        'query_args' => array( 'type' => ['image', 'video'] ), // Only images or videos attachment
 	) );
 
 	$cmb_aftercontent_luoghi->add_field( array(

--- a/inc/admin/scheda_progetto.php
+++ b/inc/admin/scheda_progetto.php
@@ -349,10 +349,10 @@ function dsi_add_scheda_progetto_metaboxes() {
     $cmb_undercontent->add_field( array(
         'id'         => $prefix . 'gallery',
         'name'       => __( 'Galleria', 'design_scuole_italia' ),
-        'desc'       => __( 'Galleria di immagini  significative relative al progetto, corredate da didascalia', 'design_scuole_italia' ),
+        'desc'       => __( 'Galleria di immagini o video significativi relativi al progetto, corredati da didascalia (per i video, verrà mostrata una copertina che corrisponde all\'immagine in evidenza del video, che si può impostare nella sezione "Media" di WordPress; se assente, verrà usata l\'immagine in evidenza del post)', 'design_scuole_italia' ),
         'type' => 'file_list',
         // 'preview_size' => array( 100, 100 ), // Default: array( 50, 50 )
-        'query_args' => array( 'type' => 'image' ), // Only images attachment
+        'query_args' => array( 'type' => ['image', 'video'] ), // Only images or videos attachment
     ) );
 
 

--- a/template-parts/single/gallery.php
+++ b/template-parts/single/gallery.php
@@ -10,10 +10,36 @@ foreach ($gallery as $ida=>$urlg){
 	<li class="splide__slide">
 		<div class="it-single-slide-wrapper gallery-item h-100">
 				<figure>
-					<a href="<?php echo $urlg; ?>" aria-label="Visualizza foto: <?php echo $attach->post_title; ?>">
-						<?php dsi_get_img_from_url($urlg); ?>
-					</a>
 					<?php
+						if (wp_attachment_is('video', $ida)) {
+							$image_url = get_the_post_thumbnail_url($ida) ?: get_the_post_thumbnail_url();
+						?>
+							<a href="<?php echo $urlg; ?>" target="_blank" aria-label="Visualizza video: <?php echo $attach->post_title; ?>">
+								<div class="video-wrapper shadow-none rounded-0">
+									<?php
+									if($image_url){
+										dsi_get_img_from_url($image_url);
+									}
+									else
+									{
+									?>
+										<div class="bg-secondary" style="height: 320px"></div>
+										<?php
+									}
+									?>
+									<svg class="svg-play">
+										<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-play"></use>
+									</svg>
+								</div>
+							</a>
+						<?php
+						} else {
+						?>
+							<a href="<?php echo $urlg; ?>" aria-label="Visualizza foto: <?php echo $attach->post_title; ?>">
+								<?php dsi_get_img_from_url($urlg); ?>
+							</a>
+						<?php
+						}
 					if (!empty($attach->post_excerpt)) {
 					?>
 						<figcaption><?php echo $attach->post_excerpt; ?></figcaption>


### PR DESCRIPTION
## Descrizione

La modifica fa in modo che si possano selezionare anche i video nelle gallerie multimediali di documenti, eventi, luoghi e progetti, e che questi vengano mostrati con l'immagine in evidenza del video stesso (altrimenti del post, se assente) e un link ad una nuova scheda in cui riprodurlo.

![image](https://github.com/italia/design-scuole-wordpress-theme/assets/13221786/2cc2113f-2d1e-4094-8c5a-0706f8a9d255)

La modifica si è resa necessaria perché una scuola ha lamentato la rappresentazione errata dei video inseriti nella galleria di un progetto, precedentemente mostrati così:

![image](https://github.com/italia/design-scuole-wordpress-theme/assets/13221786/2f50423f-ec34-47b8-81a9-cedfe3ed029b)

La soluzione ottimale sarebbe mostrare il video all'interno del carousel con il player di WordPress (con `wp_video_shortcode(["src" => $url_del_video])` ad esempio) ma questo causa dei problemi quando si scorre il cursore del mouse sulla barra di avanzamento in quanto si sposta tutto il carousel; inoltre al ritorno dallo schermo intero le dimensioni del carousel vengono compromesse.

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->