### PR TITLE
corretto tag  $testo_servizi da H2 a P

### DIFF
--- a/template-parts/hero/servizi.php
+++ b/template-parts/hero/servizi.php
@@ -29,7 +29,7 @@ $testo_servizi = dsi_get_option("testo_servizi", "servizi");
 				<div class="hero-title text-left">
 					<h1 class="p-0 mb-2"><?php _e("Servizi", "design_scuole_italia"); ?></h1>
 					<?php if ($testo_servizi) { ?>
-						<h2 class="h4 font-weight-normal"><?php echo $testo_servizi; ?></h2>
+						<p class="h4 font-weight-normal"><?php echo $testo_servizi; ?></p>
 					<?php } ?>
 				</div><!-- /hero-title -->
 			</div><!-- /col-md-5 -->


### PR DESCRIPTION
Correzione tag pagina dei servizi

## Descrizione

Fixes #693

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->