### PR TITLE
 Corretta la sezione "La storia della scuola"

### DIFF
--- a/template-parts/hero/page.php
+++ b/template-parts/hero/page.php
@@ -11,7 +11,7 @@ $testo_sezione_organizzazione = dsi_get_option("testo_sezione_organizzazione", "
             <div class="col-md-5">
                 <div class="hero-title text-left">
                     <h1 class="p-0 mb-2"><?php the_title(); ?></h1>
-                    <h2 class="h4 font-weight-normal"><?php echo get_the_content(); ?></h2>
+                    <p class="h4 font-weight-normal"><?php echo get_the_content(); ?></p>
                 </div><!-- /hero-title -->
             </div><!-- /col-md-5 -->
         </div><!-- /row -->

--- a/template-parts/home/i-numeri.php
+++ b/template-parts/home/i-numeri.php
@@ -11,7 +11,7 @@ $media = intval($studenti / $classi);
 			<div class="row variable-gutters">
 				<div class="col-md-6">
 					<div class="title-section">
-						<h3 class="mb-3 mb-xl-5"><?php _e("La scuola in numeri", "design_scuole_italia"); ?></h3>
+						<h2 class="h3 mb-3 mb-xl-5"><?php _e("La scuola in numeri", "design_scuole_italia"); ?></h2>
 						<p class="mb-0"><?php echo dsi_get_option("numeri_descrizione", "la_scuola"); ?></p>
 					</div><!-- /title-section -->
 				</div><!-- /col-md-6 -->

--- a/template-parts/home/le-carte.php
+++ b/template-parts/home/le-carte.php
@@ -8,7 +8,7 @@ if(is_array($gruppo_carte) && count($gruppo_carte) > 0) {
 			<div class="row variable-gutters mt-0 mt-xl-5">
 				<div class="col">
 					<div class="title-section text-center mb-5">
-						<h3 class="mb-2"><?php _e( "Le carte della scuola", "design_scuole_italia" ); ?></h3>
+						<h2 class="h3 mb-2"><?php _e( "Le carte della scuola", "design_scuole_italia" ); ?></h2>
 						<p><?php echo dsi_get_option( "descrizione_carte", "la_scuola" ); ?></p>
 					</div><!-- /title-section -->
 				</div><!-- /col -->

--- a/template-parts/home/strutture.php
+++ b/template-parts/home/strutture.php
@@ -39,7 +39,7 @@ global $struttura;
 		<div class="row variable-gutters">
 			<div class="col-md-6">
 				<div class="big-quote big-quote-secondary">
-					<h3><?php echo $descrizione_strutture; ?></h3>
+					<h2 class="h3"><?php echo $descrizione_strutture; ?></h2>
 				</div><!-- /big-quote -->
 			</div><!-- /col-md-6 -->
 			<div class="col-md-5 offset-md-1 cards-wrapper-center">

--- a/template-parts/home/timeline.php
+++ b/template-parts/home/timeline.php
@@ -4,12 +4,12 @@
 $timeline = dsi_get_option( "timeline", "la_scuola" );
 if(is_array($timeline) && count($timeline) > 0) {
 	?>
-	<section class="section section-padding bg-blue-dark">
-		<div class="container">
+	<section class="section-hero bg-blue-dark py-5">
+		<div class="container section-padding bg-blue-dark">
 			<div class="row variable-gutters mt-0 mt-xl-2">
 				<div class="col">
 					<div class="title-section text-center mb-5">
-						<h3 class="mb-2" style="color: #ffffff;"><?php _e( "La storia della scuola", "design_scuole_italia" ); ?></h3>
+						<h2 class="mb-2" style="color: #ffffff;"><?php _e( "La storia della scuola", "design_scuole_italia" ); ?></h2>
 						<p style="color: #ffffff;"><?php echo dsi_get_option( "descrizione_scuola", "la_scuola" ); ?></p>
 					</div><!-- /title-section -->
 				</div><!-- /col -->
@@ -28,9 +28,9 @@ if(is_array($timeline) && count($timeline) > 0) {
 									<div class="it-single-slide-wrapper h-100">	
 										<div class="card card-img card-serif">
 											<div class="card-body px-0">
-												<h5><?php echo date_i18n("F Y", $timestamp); ?></h5>
-												<h3><?php echo $item["titolo_timeline"] ?></h3>
-												<p><?php echo $item["descrizione_timeline"] ?></p>
+												<h3 class="mb-1"><?php echo $item["titolo_timeline"] ?></h3>
+												<span class="h5"><?php echo date_i18n("F Y", $timestamp); ?></span>
+												<p class="mt-3"><?php echo $item["descrizione_timeline"] ?></p>
 											</div><!-- /card-body -->
 										</div><!-- /card -->
 									</div><!-- /item -->

--- a/template-parts/struttura/card-large.php
+++ b/template-parts/struttura/card-large.php
@@ -11,7 +11,7 @@ if($tipologie){
 		<?php get_template_part("template-parts/svg/icona",$tipologia); ?>
 
         <div class="card-icon-content"  id="card-desc-<?php echo $struttura->ID; ?>">
-			<h4><?php echo $struttura->post_title; ?></h4>
+			<h3 class="h4"><?php echo $struttura->post_title; ?></h3>
 		</div><!-- /card-icon-content -->
 	</div><!-- /card-body -->
 	</a>


### PR DESCRIPTION
Correzione salti di H della sezione "La storia della scuola"

## Descrizione
Nella panoramica del menu scuola, sezione "La storia della scuola", proponiamo di organizzare i contenuti in questo modo:
- la storia della scuola H2 (così come gli altri titoli delle sezioni nella stessa pagina)
- data in P e spostandola sotto il titolo
- titoli degli accadimenti H3
Fixes #690

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->