### PR TITLE
Miglioramento pagina risultati della ricerca

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -495,3 +495,19 @@ function dsi_login_redirect( $redirect_to, $request, $user ) {
 }
 
 add_filter( 'login_redirect', 'dsi_login_redirect', 10, 3 );
+
+//riscrivi il meta title nella pagina dei risultati della ricerca
+function custom_search_title($title) {
+    if ( is_search() ) {
+        // Get the search query
+        $search_query = get_search_query();
+
+        if ( empty($search_query) ) {
+            $title['title'] = esc_html__('Risultati della ricerca', 'design_scuole_italia'); 
+        } else {
+            $title['title'] = sprintf(esc_html__('Risultati della ricerca per "%s"', 'design_scuole_italia'), $search_query);
+        }
+	}
+    return $title;
+}
+add_filter('document_title_parts', 'custom_search_title');

--- a/search.php
+++ b/search.php
@@ -9,107 +9,216 @@
 
 get_header();
 ?>
-    <main id="main-container" class="main-container petrol">
-		<?php get_template_part("template-parts/common/breadcrumb"); ?>
+<main id="main-container" class="main-container petrol">
+    <?php get_template_part("template-parts/common/breadcrumb"); ?>
 
-        <section class="section bg-white py-2 py-lg-3 py-xl-5">
-            <div class="container">
-                <div class="row variable-gutters">
-                    <div class="col-lg-5 col-md-8 offset-lg-3">
-                        <div class="section-title">
-                            <p><?php
-                                if(get_search_query() != "")
-                                    _e("Risultati della ricerca per:", "design_scuole_italia");
-                                ?></p>
-                            <h1 class="h2 mb-0"><?php if(get_search_query() != "")
-                                                        echo get_search_query();
-                                                    else
-                                                        _e("Ricerca generica", "design-scuole-italia");
+    <section class="section bg-white py-2 py-lg-3 py-xl-5">
+        <div class="container">
+            <div class="row variable-gutters">
+                <div class="col-lg-5 col-md-8 offset-lg-3">
+                    <div class="section-title">
+                        <h1>
+                            <?php
+                            global $wp_query;
+// Modifico la risposta in base a quanti risultati sono disponibili
+                            if ($wp_query->found_posts < 1) {
+                                $result = "Nessun risultato";
+                            } else if ($wp_query->found_posts < 2) {
+                                $result = $wp_query->found_posts . " risultato";
+                            } else {
+                                $result = $wp_query->found_posts . " risultati";
+                            }
+                            echo $result . " ";
+                            ?>
+                            <?php if (get_search_query() != "")
+// Aggiungo il parametro di ricerca preceduto da "per" (disponibile)
+                                echo "per \"" . get_search_query() . "\""; ?>
+                        </h1>
 
-                            ?></h1>
-                            <p>
-								<?php
-                                $str = "";
-								if(isset($_GET["type"]) && $_GET["type"] != "") {
-									if ( $_GET["type"] == "any" ) {
-										$str = __( "su <span>tutto il sito</span>", "design_scuole_italia" );
-									} else if ( $_GET["type"] == "school" ) {
-										$str = __( "nel <span>materiale relativo alla scuola</span>", "design_scuole_italia" );
-									} else if ( $_GET["type"] == "news" ) {
-										$str = __( "in <span>notizie ed eventi</span>", "design_scuole_italia" );
-									} else if ( $_GET["type"] == "service" ) {
-										$str = __( "nei <span>servizi</span>", "design_scuole_italia" );
-									} else if ( $_GET["type"] == "education" ) {
-										$str = __( "nella <span>didattica</span>", "design_scuole_italia" );
-									} else if ( $_GET["type"] == "class" ) {
-										$str = __( "nelle <span>materiale relativo alle classi</span>", "design_scuole_italia" );
-									}
-								}else{
-									$str = __( "in base ai filtri selezionati", "design_scuole_italia" );
+                        <p class="d-block">
+
+                            <?php if (isset($_GET["post_types"]) || isset($_GET["post_terms"]) || isset($_GET["type"]) ) {  
+                            // Aggiungo la frase "in base ai filtri selezionati:" se ce ne sono
+                            echo "in base ai filtri selezionati:<br>";
+                            } ?>
+
+                            <?php
+                            if (!isset($_GET["post_types"])) {
+
+                                $post_type_links = array();
+                                $post_types = array();
+
+                                if (isset($_GET["type"]) && $_GET["type"] == "school") {
+                                    $post_types = array("documento", "luogo", "struttura", "page");
                                 }
-								echo " ".$str;
-								?>
-                            </p>
-                        </div><!-- /title-section -->
-                    </div><!-- /col-lg-5 col-md-8 offset-lg-2 -->
 
-                    <div class="col-lg-3 col-md-4 offset-lg-1">
-						<?php get_template_part("template-parts/single/actions"); ?>
-                    </div><!-- /col-lg-3 col-md-4 offset-lg-1 -->
-                </div><!-- /row -->
-            </div><!-- /container -->
-        </section><!-- /section -->
-        
-        <?php 
-        get_template_part( 'template-parts/search/toggle-search-filters-mobile' );
-        ?>
+                                if (isset($_GET["type"]) && $_GET["type"] == "service") {
+                                    $post_types = array("servizio", "indirizzo");
+                                }
 
-        <section class="section bg-gray-light">
-            <div class="container">
-                <div class="row variable-gutters sticky-sidebar-container">
-                    <div class="col-lg-3 bg-white bg-white-left">
-	                    <?php get_template_part("template-parts/search/filters"); ?>
-                    </div>
-                    <div class="col-lg-7 offset-lg-1 pt84">
-                        <h2 class="sr-only">Risultati di ricerca</h2>
-						<?php if ( have_posts() ) : ?>
-							<?php
-							/* Start the Loop */
-							while ( have_posts() ) :
-								the_post();
-								get_template_part( 'template-parts/list/article', get_post_type() );
+                                if (isset($_GET["type"]) && $_GET["type"] == "education") {
+                                    $post_types = array("scheda_didattica", "scheda_progetto");
+                                }
 
-							endwhile;
+                                if (isset($_GET["type"]) && $_GET["type"] == "news") {
+                                    $post_types = array("evento", "post", "circolare");
+                                }
 
+                                if (isset($_GET["type"]) && $_GET["type"] == "any") {
+                                    $post_types = array("documento", "luogo", "struttura", "page", "servizio", "indirizzo", "scheda_didattica", "scheda_progetto", "evento", "post", "circolare");
+                                }
 
-							if((get_query_var( 'paged' ) == $wp_query->max_num_pages || $wp_query->max_num_pages == 1) && !isset($_GET["post_terms"])){
-                            	$s_query = get_search_query();
-								get_template_part( 'template-parts/search/argomenti' );
+                                foreach ($post_types as $post_type_name) {
+                                    $post_type = get_post_type_object($post_type_name);
+
+                                    if (!empty($post_type)) {
+                                        // Check if the label is "Articoli"
+                                        if ($post_type->label === "Articoli") {
+                                            // Special link for "Articoli"
+                                            $link = 'tipologia-articolo/articoli/';
+                                        } else {
+                                            // Default link
+                                            if (isset($post_type->rewrite['slug']) && is_array($post_type->rewrite)) {
+                                                $link = esc_url('/' . $post_type->rewrite['slug']);
+                                            } else {
+                                                // Handle the case where rewrite or slug is not available
+                                                $link = esc_url('/');
+                                            }
+                                        }
+
+                                        // Escape the label for output
+                                        $post_type_links[] = '<a class="badge badge-sm badge-pill badge-outline-primary" href="' . $link . '">' . esc_html($post_type->label) . '</a>';
+                                    }
+                                }
+
+                                echo implode(' ', $post_type_links);
                             }
 
-							?>
-                            <nav class="pagination-wrapper" aria-label="Navigazione della pagina">
-								<?php echo dsi_bootstrap_pagination(); ?>
-                            </nav>
-						<?php
-						else :
+                            ?>
 
-							get_template_part( 'template-parts/content', 'none' );
+                            <?php
+                            if (isset($_GET["post_types"])) {
+                                // Sanitize input
+                                $post_types = array_map('sanitize_text_field', $_GET["post_types"]);
 
-							if(!isset($_GET["post_terms"])) {
-                            	$s_query = get_search_query();
-								get_template_part( 'template-parts/search/argomenti' );
+                                $post_type_links = array();
+
+                                foreach ($post_types as $post_type_name) {
+                                    $post_type = get_post_type_object($post_type_name);
+
+                                    if (!empty($post_type)) {
+                                        // Check if the label is "Articoli"
+                                        if ($post_type->label === "Articoli") {
+                                            // Special link for "Articoli"
+                                            $link = 'tipologia-articolo/articoli/';
+                                        } else {
+                                            // Default link
+                                            if (isset($post_type->rewrite['slug']) && is_array($post_type->rewrite)) {
+                                                $link = esc_url('/' . $post_type->rewrite['slug']);
+                                            } else {
+                                                // Handle the case where rewrite or slug is not available
+                                                $link = esc_url('/');
+                                            }
+                                        }
+
+                                        // Escape the label for output
+                                        $post_type_links[] = '<a class="badge badge-sm badge-pill badge-outline-primary" href="' . $link . '">' . esc_html($post_type->label) . '</a>';
+                                    }
+                                }
+
+                                echo implode(' ', $post_type_links);
                             }
+                            ?>
 
-						endif;
+                            <?php
+                            if (isset($_GET["post_terms"])) {
+                            // aggiungo badges degli argomenti selezionati nel filtro    
+                                $post_terms = $_GET["post_terms"];
+
+                                $term_links = array();
+
+                                foreach ($post_terms as $term_id) {
+                                    $term = get_term($term_id);
+
+                                    if (!is_wp_error($term) && !empty($term)) {
+                                        $term_links[] = '<a class="badge badge-sm badge-pill badge-outline-primary" href="argomento/' . $term->slug . '">' . $term->name . '</a>';
+                                    }
+
+                                }
+                                echo implode(' ', $term_links);
+                            }
+                            ?>
 
 
-						?>
-                    </div><!-- /col-lg-8 -->
-                </div><!-- /row -->
-            </div><!-- /container -->
-        </section>
-    </main>
+                        </p>
+                    </div><!-- /title-section -->
+                </div><!-- /col-lg-5 col-md-8 offset-lg-2 -->
+
+                <div class="col-lg-3 col-md-4 offset-lg-1">
+                    <?php get_template_part("template-parts/single/actions"); ?>
+                </div><!-- /col-lg-3 col-md-4 offset-lg-1 -->
+            </div><!-- /row -->
+        </div><!-- /container -->
+    </section><!-- /section -->
+
+
+
+    <section class="section bg-white border-top border-bottom d-block d-lg-none">
+        <div class="container d-flex justify-content-between align-items-center py-3">
+            <h3 class="h6 text-uppercase mb-0 label-filter"><strong>Filtri</strong></h3>
+            <a class="toggle-search-results-mobile toggle-menu menu-search push-body mb-0" href="#">
+                <svg class="svg-filters">
+                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#svg-filters"></use>
+                </svg>
+            </a>
+        </div>
+    </section>
+    <section class="section bg-gray-light">
+        <div class="container">
+            <div class="row variable-gutters sticky-sidebar-container">
+                <div class="col-lg-3 bg-white bg-white-left">
+                    <?php get_template_part("template-parts/search/filters"); ?>
+                </div>
+                <div class="col-lg-7 offset-lg-1 pt84">
+                    <h2 class="sr-only">Risultati di ricerca</h2>
+                    <?php if (have_posts()): ?>
+                        <?php
+                        /* Start the Loop */
+                        while (have_posts()):
+                            the_post();
+                            get_template_part('template-parts/list/article', get_post_type());
+
+                        endwhile;
+
+
+                        if ((get_query_var('paged') == $wp_query->max_num_pages || $wp_query->max_num_pages == 1) && !isset($_GET["post_terms"])) {
+                            $s_query = get_search_query();
+                            get_template_part('template-parts/search/argomenti');
+                        }
+
+                        ?>
+                        <nav class="pagination-wrapper" aria-label="Navigazione della pagina">
+                            <?php echo dsi_bootstrap_pagination(); ?>
+                        </nav>
+                        <?php
+                    else:
+
+                        get_template_part('template-parts/content', 'none');
+
+                        if (!isset($_GET["post_terms"])) {
+                            $s_query = get_search_query();
+                            get_template_part('template-parts/search/argomenti');
+                        }
+
+                    endif;
+
+
+                    ?>
+                </div><!-- /col-lg-8 -->
+            </div><!-- /row -->
+        </div><!-- /container -->
+    </section>
+</main>
 
 <?php
 get_footer();

--- a/search.php
+++ b/search.php
@@ -20,7 +20,7 @@ get_header();
                         <h1>
                             <?php
                             global $wp_query;
-// Modifico la risposta in base a quanti risultati sono disponibili
+// Modifico la risposta in base al numero di risultati
                             if ($wp_query->found_posts < 1) {
                                 $result = "Nessun risultato";
                             } else if ($wp_query->found_posts < 2) {
@@ -31,7 +31,7 @@ get_header();
                             echo $result . " ";
                             ?>
                             <?php if (get_search_query() != "")
-// Aggiungo il parametro di ricerca preceduto da "per" (disponibile)
+// Aggiungo il parametro di ricerca preceduto da "per" solo quando serve
                                 echo "per \"" . get_search_query() . "\""; ?>
                         </h1>
 
@@ -43,6 +43,7 @@ get_header();
                             } ?>
 
                             <?php
+// Aggiungo i badge dei filtri corrispondenti al "type"
                             if (!isset($_GET["post_types"])) {
 
                                 $post_type_links = array();
@@ -94,9 +95,7 @@ get_header();
                                 echo implode(' ', $post_type_links);
                             }
 
-                            ?>
 
-                            <?php
                             if (isset($_GET["post_types"])) {
                                 // Sanitize input
                                 $post_types = array_map('sanitize_text_field', $_GET["post_types"]);

--- a/template-parts/common/breadcrumb.php
+++ b/template-parts/common/breadcrumb.php
@@ -16,8 +16,8 @@
 		                    'network'         => false,
 		                    'show_title'      => true,
 		                    'show_browse'     => false,
-		                    'labels'          => array(
-			                    'search'      => esc_html__( 'Risultati Ricerca: %s','design_scuole_italia' ),
+							'labels'          => array(
+			                    'search'      => esc_html__( 'Risultati della ricerca','design_scuole_italia' ),
                             ),
 		                    'post_taxonomy' => array(
 			                     'servizio'  => 'tipologia-servizio', // 'post' post type and 'post_tag' taxonomy

--- a/template-parts/search/filters-tag.php
+++ b/template-parts/search/filters-tag.php
@@ -45,7 +45,7 @@ $current_term = get_queried_object();
                     ?>
                     <li>
                         <div class="form-check my-0">
-                            <input type="checkbox" class="custom-control-input" name="post_types[]" value="<?php echo $type; ?>" id="check-<?php echo $type; ?>" <?php if(in_array($type, $post_types)) echo " checked "; ?> onChange="this.form.submit()">
+                            <input type="checkbox" class="custom-control-input" name="post_types[]" value="<?php echo $type; ?>" id="check-<?php echo $type; ?>" <?php if(in_array($type, $post_types)) echo " checked "; ?> onChange="this.form.submit()" autocomplete="off">
                             <label class="mb-0" for="check-<?php echo $type; ?>"><?php echo $name; ?></label>
                         </div>
                     </li>

--- a/template-parts/search/filters.php
+++ b/template-parts/search/filters.php
@@ -45,7 +45,7 @@ if(isset($_GET["post_terms"]))
                 ?>
                 <li>
                     <div class="form-check my-0">
-                        <input type="checkbox" class="custom-control-input" name="post_types[]" value="<?php echo $type; ?>" id="check-<?php echo $type; ?>" <?php if(in_array($type, $post_types)) echo " checked "; ?> onChange="this.form.submit()">
+                        <input type="checkbox" class="custom-control-input" name="post_types[]" value="<?php echo $type; ?>" id="check-<?php echo $type; ?>" <?php if(in_array($type, $post_types)) echo " checked "; ?> onChange="this.form.submit()" autocomplete="off">
                         <label class="mb-0" for="check-<?php echo $type; ?>"><?php echo $name; ?></label>
                     </div>
                 </li>
@@ -76,7 +76,7 @@ if(isset($_GET["post_terms"]))
                     ?>
                 <li>
                     <div class="custom-control custom-checkbox custom-checkbox-outline">
-               	             <input type="checkbox" class="custom-control-input" name="post_terms[]" value="<?php echo $term->term_id; ?>" id="check-<?php echo $term->slug; ?>" <?php if(in_array($term->term_id, $post_terms)) echo " checked "; ?> onChange="this.form.submit()">
+               	             <input type="checkbox" class="custom-control-input" name="post_terms[]" value="<?php echo $term->term_id; ?>" id="check-<?php echo $term->slug; ?>" <?php if(in_array($term->term_id, $post_terms)) echo " checked "; ?> onChange="this.form.submit()" autocomplete="off">
                              <label class="custom-control-label" for="check-<?php echo $term->slug; ?>"><?php echo $term->name; ?></label>
                	         </div>
                         </li>
@@ -92,7 +92,7 @@ if(isset($_GET["post_terms"]))
                 ?>
                 <li>
                     <div class="custom-control custom-checkbox custom-checkbox-outline">
-                        <input type="checkbox" class="custom-control-input" name="post_terms[]" value="<?php echo $term->term_id; ?>" id="check-<?php echo $term->slug; ?>" <?php if(in_array($term->term_id, $post_terms)) echo " checked "; ?> onChange="this.form.submit()">
+                        <input type="checkbox" class="custom-control-input" name="post_terms[]" value="<?php echo $term->term_id; ?>" id="check-<?php echo $term->slug; ?>" <?php if(in_array($term->term_id, $post_terms)) echo " checked "; ?> onChange="this.form.submit()" autocomplete="off">
                         <label class="custom-control-label" for="check-<?php echo $term->slug; ?>"><?php echo $term->name; ?></label>
                     </div>
                 </li>

--- a/template-parts/search/filters.php
+++ b/template-parts/search/filters.php
@@ -58,16 +58,23 @@ if(isset($_GET["post_terms"]))
     <?php
     }
     ?>
-        <h3 class="h6 text-uppercase"><strong><?php _e("Argomenti", "design_scuole_italia"); ?></strong></h3>
-        <ul data-element="all-topics">
-            <?php
-            $terms = get_terms( array(
+
+    <?php           
+                $terms = get_terms( array(
                 'taxonomy' => 'post_tag',
                 'hide_empty' => true,
                 'orderby'    => 'count',
                 'order'   => 'DESC'
             ) );
             $idTerms = array_column($terms, 'term_id');
+            
+            if (!empty($terms)) { ?>   
+
+
+        <h3 class="h6 text-uppercase"><strong><?php _e("Argomenti", "design_scuole_italia"); ?></strong></h3>
+        <ul data-element="all-topics">
+            <?php
+
 
             foreach($post_terms as $post_term) {
                 $found = array_search($post_term, $idTerms);
@@ -100,5 +107,8 @@ if(isset($_GET["post_terms"]))
             }
             ?>
         </ul>
+    <?php
+        }
+    ?>
     </form>
 </aside>


### PR DESCRIPTION
Proponiamo alcuni miglioramenti alla pagina dei risultati delle ricerche, per risolvere alcune issues e rendere più coerenti tra loro testi, intestazioni, breadcrumb, meta titles e filtri. 

## Descrizione
Le principali modifiche al codice sono le seguenti:

- I filtri selezionati nella pagina di ricerca sono elencati come badges, subito sotto la scritta "in base ai filtri selezionati:". 

- La intestazione principale dei risultati, non reca più la frase "Ricerca generica" ma riproduce la dicitura "nessun risultato", "1 risultato", "n risultati", ovviamente in base al numero di risultati trovati. 

- Quando viene effettuata la ricerca dalla modale e viene utilizzato uno dei bottoni "Cerca nella sezione scuola", "Cerca tra le novità", "Cerca nei servizi", "Cerca nella didattica" o "Cerca in tutto il sito", nella pagina dei risultati compariva il paragrafo con, rispettivamente, "nel materiale relativo alla scuola", "in notizie ed eventi", "nei servizi", "nella didattica", "su tutto il sito". Ora, quando viene effettuata la stessa ricerca dalla modale, nella pagina dei risultati compare l'elenco dei singoli filtri selezionati.

- Quanto al breadcrumb, proponiamo di cambiare la attuale dicitura "Risultati Ricerca: {parola cercata}"con "Risultati della ricerca", senza aggiungere altro, visto che i dettagli sono disponibili subito sotto e fornirli due volte ci sembra ridondante. 

- Il metatitle è stato allineato al breadcrumb. Quando non c'è una stringa tra i parametri di ricerca, reca il testo "Risultati della ricerca - {nome del sito}" invece che "Risultati della ricerca per "" - {nome del sito}" 

- Abbiamo aggiunto l'attributo autocomplete="off" ai checkbox dei filtri della ricerca, per risolvere la issue #725

- Abbiamo modificato la sezione dei filtri, in modo che tutto, compresa la intestazione "argomenti" in H3, si veda solo quando gli argomenti sono utilizzati (prima compariva il titoletto anche quando le scuole non usano gli argomenti)


Fixes:  #688 #725

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->