### PR TITLE
Integrazione OAuth2 con il componente di autenticazione MIM

### DIFF
--- a/template-parts/common/access-modal.php
+++ b/template-parts/common/access-modal.php
@@ -71,6 +71,11 @@
                                                 <button type="submit" class="btn btn-white btn-block rounded" name="login" value="Accedi"><?php _e("Accedi", "design_scuole_italia"); ?></button>
                                             </div>
                                         </div>
+                                        <?php if(in_array('daggerhart-openid-connect-generic/openid-connect-generic.php', apply_filters('active_plugins', get_option('active_plugins')))){?>
+                                            <div class="col text-center btn btn-primary p-0">
+                                                <?php echo do_shortcode("[openid_connect_generic_login_button]"); ?>
+                                            </div>
+                                        <?php }?>
                                         <!-- <div class="row variable-gutters">
                                             <div class="col text-center">
                                                 <p>Non hai un account? <a href="#">Iscriviti</a></p>


### PR DESCRIPTION
## Descrizione

La modifica richiesta dal MIM favorisce l'adozione di SPID e CIE nelle scuole che utilizzano WordPress, tramite integrazione OAuth2 con il componente di autenticazione del MIM. L'intervento permette di interagire con un plugin esistente e migliora l'esperienza utente. Ora il pulsante "Entra con SPID/CIE" viene visualizzato direttamente nella pagina di login del tema della scuola, evitando il reindirizzamento alla pagina predefinita del plugin.

## Checklist

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).