### PR TITLE
Testo alternativo e didascalia per le immagini in evidenza

### DIFF
--- a/page.php
+++ b/page.php
@@ -16,7 +16,12 @@ get_header();
         ?>
         <?php if(has_post_thumbnail($post)){ ?>
         <section class="section bg-white article-title">
-            <div class="title-img" style="background-image: url('<?php echo $image_url; ?>');"></div>
+            <?php 
+                $attachment_id = get_post_thumbnail_id(); // Get the featured image ID
+                $didascalia = wp_get_attachment_caption($attachment_id);
+                $alt_text = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
+            ?>
+            <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-black text-white"><?php echo $didascalia; ?></div><?php } ?></div>
             <?php
             $colsize = 6;
             }else{

--- a/single-evento.php
+++ b/single-evento.php
@@ -39,7 +39,7 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                         ?>
                         <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img"
                                 aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?>
-                                <div class="w-100 p-4 bg-greendark text-white"><?php echo $didascalia; ?></div><?php } ?>
+                                <div class="w-100 p-4 bg-black text-white"><?php echo $didascalia; ?></div><?php } ?>
                         </div>
                         <?php
                     } else { ?>

--- a/single-evento.php
+++ b/single-evento.php
@@ -32,7 +32,15 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
 
 				<?php if (has_post_thumbnail($post)) { ?>
                     <section class="section bg-white article-title">
-                        <div class="title-img" style="background-image: url('<?php echo $image_url; ?>');"></div>
+                        <?php
+                        $attachment_id = get_post_thumbnail_id(); // Get the featured image ID
+                        $didascalia = wp_get_attachment_caption($attachment_id);
+                        $alt_text = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
+                        ?>
+                        <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img"
+                                aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?>
+                                <div class="w-100 p-4 bg-greendark text-white"><?php echo $didascalia; ?></div><?php } ?>
+                        </div>
                         <?php
                     } else { ?>
                         <section class="section bg-white article-title">

--- a/single-luogo.php
+++ b/single-luogo.php
@@ -72,7 +72,7 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                     $didascalia = wp_get_attachment_caption($attachment_id);
                     $alt_text = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
                 ?>
-                <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-redbrown text-white"><?php echo $didascalia; ?></div><?php } ?></div>
+                <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-black text-white"><?php echo $didascalia; ?></div><?php } ?></div>
             <?php
             
             } else { ?>

--- a/single-luogo.php
+++ b/single-luogo.php
@@ -67,7 +67,12 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
 
         <?php if (has_post_thumbnail($post)) { ?>
         <section class="section bg-white article-title">
-            <div class="title-img" style="background-image: url('<?php echo $image_url; ?>');"></div>
+                <?php 
+                    $attachment_id = get_post_thumbnail_id(); // Get the featured image ID
+                    $didascalia = wp_get_attachment_caption($attachment_id);
+                    $alt_text = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
+                ?>
+                <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-redbrown text-white"><?php echo $didascalia; ?></div><?php } ?></div>
             <?php
             
             } else { ?>

--- a/single-scheda_progetto.php
+++ b/single-scheda_progetto.php
@@ -43,7 +43,12 @@ $persone_show_card = dsi_get_option("persone_show_card", "persone");
 
 
             <section class="section bg-white article-title">
-                <div class="title-img" <?php if($image_url){ ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?>></div>
+                <?php 
+                    $attachment_id = get_post_thumbnail_id(); // Get the featured image ID
+                    $didascalia = wp_get_attachment_caption($attachment_id);
+                    $alt_text = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
+                ?>
+                <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-bluelectric text-white"><?php echo $didascalia; ?></div><?php } ?></div>
                 <div class="container">
                     <div class="row variable-gutters">
                         <div class="col-md-6 d-flex align-items-center">

--- a/single-scheda_progetto.php
+++ b/single-scheda_progetto.php
@@ -48,7 +48,7 @@ $persone_show_card = dsi_get_option("persone_show_card", "persone");
                     $didascalia = wp_get_attachment_caption($attachment_id);
                     $alt_text = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
                 ?>
-                <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-bluelectric text-white"><?php echo $didascalia; ?></div><?php } ?></div>
+                <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-black text-white"><?php echo $didascalia; ?></div><?php } ?></div>
                 <div class="container">
                     <div class="row variable-gutters">
                         <div class="col-md-6 d-flex align-items-center">

--- a/single-struttura.php
+++ b/single-struttura.php
@@ -73,7 +73,12 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
 
             <section class="section bg-white article-title">
                 <?php if(has_post_thumbnail($post)){ ?>
-                <div class="title-img"  style="background-image: url('<?php echo $image_url; ?>');"></div>
+                <?php 
+                    $attachment_id = get_post_thumbnail_id(); // Get the featured image ID
+                    $didascalia = wp_get_attachment_caption($attachment_id);
+                    $alt_text = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
+                ?>
+                <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-redbrown text-white"><?php echo $didascalia; ?></div><?php } ?></div>
                 <?php }else{ ?>
                     <div class="title-img bg-redbrown bg-red-gradient d-none d-md-block ">
                         <svg width="100%" height="100%" viewBox="0 0 312 311" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">

--- a/single-struttura.php
+++ b/single-struttura.php
@@ -78,7 +78,7 @@ $user_can_view_post = dsi_members_can_user_view_post(get_current_user_id(), $pos
                     $didascalia = wp_get_attachment_caption($attachment_id);
                     $alt_text = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
                 ?>
-                <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-redbrown text-white"><?php echo $didascalia; ?></div><?php } ?></div>
+                <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-black text-white"><?php echo $didascalia; ?></div><?php } ?></div>
                 <?php }else{ ?>
                     <div class="title-img bg-redbrown bg-red-gradient d-none d-md-block ">
                         <svg width="100%" height="100%" viewBox="0 0 312 311" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">

--- a/template-parts/single/header-post.php
+++ b/template-parts/single/header-post.php
@@ -11,8 +11,12 @@ $autore = get_user_by("ID", $post->post_author);
 ?>
 <?php if(has_post_thumbnail($post)){ ?>
 <section class="section bg-white article-title article-title-author">
-
-    <div class="title-img" style="background-image: url('<?php echo $image_url; ?>');"></div>
+    <?php 
+        $attachment_id = get_post_thumbnail_id(); // Get the featured image ID
+        $didascalia = wp_get_attachment_caption($attachment_id);
+        $alt_text = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
+    ?>
+    <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-black text-white"><?php echo $didascalia; ?></div><?php } ?></div>
     <?php
     $colsize = 6;
     }else{

--- a/template-parts/single/header-post.php
+++ b/template-parts/single/header-post.php
@@ -16,7 +16,7 @@ $autore = get_user_by("ID", $post->post_author);
         $didascalia = wp_get_attachment_caption($attachment_id);
         $alt_text = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
     ?>
-    <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-black text-white"><?php echo $didascalia; ?></div><?php } ?></div>
+    <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-greendark text-white"><?php echo $didascalia; ?></div><?php } ?></div>
     <?php
     $colsize = 6;
     }else{

--- a/template-parts/single/header-post.php
+++ b/template-parts/single/header-post.php
@@ -16,7 +16,7 @@ $autore = get_user_by("ID", $post->post_author);
         $didascalia = wp_get_attachment_caption($attachment_id);
         $alt_text = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
     ?>
-    <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-greendark text-white"><?php echo $didascalia; ?></div><?php } ?></div>
+    <div class="title-img d-flex align-items-end" <?php if ($image_url) { ?>style="background-image: url('<?php echo $image_url; ?>');" <?php } ?><?php if ($alt_text) { ?> role="img" aria-label="<?php echo $alt_text ?>" <?php } ?>><?php if ($didascalia) { ?><div class="w-100 p-4 bg-black text-white"><?php echo $didascalia; ?></div><?php } ?></div>
     <?php
     $colsize = 6;
     }else{


### PR DESCRIPTION
Modifica nelle pagine foglia dove è già prevista la visualizzazione della immagine in evidenza, per rendere accessibile il testo alternativo e la didascalia (se valorizzati i relativi campi della stessa immagine nel backend). 

## Descrizione
Il testo alternativo è reso accessibile attraverso l'utilizzo di role="img" e aria-label.
La didascalia viene aggiunta ricalcando lo stile grafico già utilizzato per la gallery, ma con i colori dello sfondo che si adattano al colore del conten type. Nel caso della pagina, il colore di sfondo scelto è il nero (mentre il testo della didascalia è sempre bianco).

Esempio didascalia per la scheda progetto (sfondo blu):
![immagine](https://github.com/user-attachments/assets/715c0ef9-e3cd-4f6b-b827-4e7eb48208de)

Esempio didascalia per evento e articoli (sfondo verde):
![immagine](https://github.com/user-attachments/assets/0f5a4499-6cab-42a0-a1eb-e70d89262448)

Esempio didascalia per luogo e per struttura (sfondo rosso):
![immagine](https://github.com/user-attachments/assets/6bf80960-89fc-4c98-84ae-ac7ae589dddb)

Esempio didascalia per pagina generica (sfondo nero):
![immagine](https://github.com/user-attachments/assets/61e46319-fa7b-4505-afe0-f8cd3974c118)

Fixes: #730 #731

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->