### PR TITLE
Aggiunta blocco modifica profilo utente in base ad una nuova capability

### DIFF
--- a/inc/actions.php
+++ b/inc/actions.php
@@ -752,3 +752,36 @@ add_filter( 'anac_filter_basexmlurl', function( $string ) { // Base URL
 
 }, 10, 3 );
 
+
+function block_profile_editing() {
+    $role = get_role( 'administrator' );
+
+    if( $role->has_cap( 'edit_own_profile' ) ) {
+        if (is_admin() && !current_user_can('edit_own_profile') && strpos($_SERVER['REQUEST_URI'], 'profile.php') !== false) {
+            wp_die(__('Non hai i permessi per modificare il tuo profilo, contatta l\'amministrazione del sito. <br /><a href="index.php">Torna alla bacheca</a>'));
+        }
+    }
+}
+add_action('admin_init', 'block_profile_editing');
+
+function remove_profile_menu_for_users() {
+    $role = get_role( 'administrator' );
+
+    if( $role->has_cap( 'edit_own_profile' ) ) {
+        if (!current_user_can('edit_own_profile')) {
+            remove_menu_page('profile.php'); // Removes the profile page from the menu
+        }
+    }
+}
+add_action('admin_menu', 'remove_profile_menu_for_users');
+
+function prevent_profile_update($errors, $update, $user) {
+    $role = get_role( 'administrator' );
+
+    if( $role->has_cap( 'edit_own_profile' ) ) {
+        if (!$update || !current_user_can('edit_own_profile')) {
+            $errors->add('no_profile_edit', __('Non hai i permessi per modificare il tuo profilo, contatta l\'amministrazione del sito.'));
+        }
+    }
+}
+add_action('user_profile_update_errors', 'prevent_profile_update', 10, 3);

--- a/inc/activation.php
+++ b/inc/activation.php
@@ -1102,6 +1102,7 @@ function dsi_create_pages_on_theme_activation() {
     $admins->add_cap( "create_roles");
     $admins->add_cap( "edit_roles");
     $admins->add_cap( "delete_roles");
+    $admins->add_cap( "edit_own_profile");
 
     //TODO: ricordarsi di aggiungere restrict_content per i ruoli abilitati
 


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
In seguito ad una modifica autonoma dei dati della persona da parte di docenti, ci è stato chiesto di inibire la possibilità di modificare il proprio profilo per evitare problemi privacy e correttezza di dati pubblicati.
Dopo vari test per capire se era possibile togliere singoli campi, abbiamo ipotizzato di bloccare l'accesso alla pagina.

Il tutto avviene per i ruoli che non hanno abilitato la capability nuova "edit_own_profile".

Chiediamo anche a voi un riscontro in quanto attualmente, se non c'è la capability, abbiamo tenuto la retrocompabilità lasciando modificare il profilo.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->