### PR TITLE
Fix notifiche di circolari non più firmabili

### DIFF
--- a/inc/welcome.php
+++ b/inc/welcome.php
@@ -38,10 +38,6 @@ function dsi_circolari_dashboard_widget() {
     
         foreach ($lista_circolari  as $idcircolare) {
             if ( get_post_status( $idcircolare ) ) {
-                $require_feedback = dsi_get_meta("require_feedback", "", $idcircolare) != "false";
-                $scadenza = dsi_get_meta("timestamp_scadenza_feedback", "", $idcircolare);
-
-                if($require_feedback && ($scadenza = '' || $scadenza > time()))
                     $real_circolari[] = $idcircolare;
             }
         }
@@ -64,15 +60,20 @@ function dsi_circolari_dashboard_widget() {
             $circolare = get_post($idcircolare);
 
             if($circolare) {
-                $numerazione_circolare = dsi_get_meta("numerazione_circolare", "", $idcircolare);
-                $require_feedback = dsi_get_meta("require_feedback", "", $idcircolare);
-                $feedback_array = dsi_get_circolari_feedback_options();
+                $require_feedback = dsi_get_meta("require_feedback", "", $idcircolare) != "false";
+                $scadenza = dsi_get_meta("timestamp_scadenza_feedback", "", $idcircolare);
 
-                echo "<li>";
-                echo "Circolare " . $numerazione_circolare . "<br>";
-                echo " <a href='" . get_permalink($circolare) . "'>" . $circolare->post_title . '</a><br>';
-                echo "Feedback richiesto: " . $feedback_array[$require_feedback] . '<hr>';
-                echo "</li>";
+                if($require_feedback && ($scadenza = '' || $scadenza > time())) {
+                    $numerazione_circolare = dsi_get_meta("numerazione_circolare", "", $idcircolare);
+                    $require_feedback = dsi_get_meta("require_feedback", "", $idcircolare);
+                    $feedback_array = dsi_get_circolari_feedback_options();
+    
+                    echo "<li>";
+                    echo "Circolare " . $numerazione_circolare . "<br>";
+                    echo " <a href='" . get_permalink($circolare) . "'>" . $circolare->post_title . '</a><br>';
+                    echo "Feedback richiesto: " . $feedback_array[$require_feedback] . '<hr>';
+                    echo "</li>";
+                }
             } 
         }
         echo "</ul>";


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

Un Ente ci ha segnalato che la rimozione delle notifiche di circolari non più firmabili ne causa la mancanza anche nell'elenco firmatari. Per evitare cambi di funzionalità non previsti ed eventuali disagi, abbiamo modificato il codice evitando la rimozione delle notifiche anche se le circolari non sono più firmabili. Verranno solo nascoste alla persona, così da ottenere lo stesso risultato.

Verranno rimosse solo le notifiche relative a circolari eliminate.

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->