### PR TITLE
fix: l'ultimo mese dell'anno scolastico corrente diventa agosto

### DIFF
--- a/inc/utils.php
+++ b/inc/utils.php
@@ -814,7 +814,7 @@ function dsi_is_scuola($post){
  */
 function dsi_get_current_anno_scolastico($year = true){
     $today_month = date("n");
-    if($today_month > 6){
+    if($today_month > 8){
         if($year) return date("Y")-0; else return dsi_convert_anno_scuola(date("Y")-0);
     }else{
         if($year) return date("Y")-1; else return dsi_convert_anno_scuola(date("Y")-1);


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Corretta la funzione che calcola l'anno scolastico in corso per farlo terminare il 31 agosto

Fixes #791

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x ] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->