### PR TITLE
fix: contrasto messaggio in home background verde

### DIFF
--- a/assets/css/overrides.css
+++ b/assets/css/overrides.css
@@ -13,3 +13,12 @@
 .calendar-vertical .calendar-date .calendar-date-description .calendar-date-description-content:before {
 margin:0
 }
+
+
+.home-message.green {
+background-color: #008055;
+}
+
+.home-message.green svg {
+background-color: #008055;
+}


### PR DESCRIPTION
## Descrizione
Gli avvisi in home con il testo bianco su sfondo verde non superavano i requisiti di contrasto minimo WCAG.
L'utilizzo di un colore verde leggermente più scuro risolve il problema di accessbilità mantenendo la coerenza cromatica tra gli elementi (testo, icona e pulsante).

Fixes italia/design-scuole-pagine-statiche#95 

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e, in caso di modifiche frontend, per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati controlli di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/manuale-operativo-design-docs/it/versione-corrente/doc/esperienza-utente/accessibilita.html).

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->